### PR TITLE
A primitive implementation of command line options for populate_mo

### DIFF
--- a/os2mo_data_import/fixture_generator/README.rst
+++ b/os2mo_data_import/fixture_generator/README.rst
@@ -3,15 +3,9 @@ Dummy data creator
 
 This application will generate tree structure containing a mock-up of a Danish
 municipality. The organisation is randomized but modelled to be somewhat realistic.
-The model is provided with a municipality code and this information is used to provided addresses and also to create fictional schools and kindergartens based on the postal
-areas in the municipality.
-
-Installation
-============
-To import the created organisation into OS2MO, the import code from the same repo
-will need to be in the Python-path:
-``export PYTHONPATH=
-$PYTHONPATH:~/os2mo-data-import-and-export/tooling/os2mo_data_import``
+The model is provided with a municipality code and this information is used to
+provided addresses and also to create fictional schools and kindergartens based on the
+postal areas in the municipality.
 
 Classification
 ==============
@@ -47,49 +41,47 @@ The two main functions ``create_org_func_tree`` and ``add_users_to_tree`` both t
 arguments that will produce a very large but much less realistic, dataset. The main
 purpose of this is to create datasets that can be used for performance tests.
 
-Specifically, if ``create_org_func_tree`` is call with ``too_many_units`` set to
-``True``, the structure will contain 25 copies of each school.
+Specifically, if ``create_org_func_tree`` is call with ``org_size`` set to
+``Size.Large``, the structure will contain 25 copies of each school.
 If ``add_users_to_tree`` is called with ``multiple_employments`` set to ``True``,
-each employee will have a large number of engagements, typically both and in the past
+each employee will have a large number of engagements, typically both in the past
 and in the future, and for most employees also in the present time.
 
 Data structure
 ==============
 The data is stored in an ``AnyTree`` data-structure. The tree will currently always
-have exactly one root (named ``root``), employees will always be leafs in the tree,
-some OUs might possibly have no employees. Additionally, all nodes have a type that
-can be either ``ou`` or ``user``.
+have either one root (default name ``root``), or two roots, employees will always be
+leafs in the tree, some OUs might possibly have no employees in which case a unit
+is a leaf. All nodes have a type that can be either ``ou`` or ``user``.
 
 The data is read by traversing the tree. The ``manager`` field contains a list of
 responsibilities if the person is a manager, otherwise an empty list.
 
 .. code-block:: python
 
-if node.type == 'ou':
-    print(node.name)  # Name of the ou
-    print(node.adresse['dar-uuid'])
-    if node.parent:
-        print(node.parent.key)  # Key for parent unit, root will have no parent
+    if node.type == 'ou':
+	print(node.name)  # Name of the ou
+	print(node.adresse['dar-uuid'])
+	if node.parent:
+	    print(node.parent.key)  # Key for parent unit, root will have no parent
 
-        if node.type == 'user':
-            print(node.name)  # Name of the employee
-            print(node.parent.key) # Key to the users unit
-            user = node.user  # All unser information is here
-            print(user[0]['cpr']) # user_key and cpr are identical in all elements
-            print(user[0]['brugervendtnoegle'])
-            for engagement in user: # An element for each engagement
-                print(engagement['adresse']['dar-uuid'])
-                print(engagement['email'])
-                print(engagement['telefon'])
-                print('engagement['role']))
-                print(engagement['association'])
-                print(engagement['manager'])
-                print('From: {}. To: {}'.format(engagement['fra'],
-                                                engagement['til']))
+	    if node.type == 'user':
+		print(node.name)  # Name of the employee
+		print(node.parent.key) # Key to the users unit
+		user = node.user  # All unser information is here
+		print(user[0]['cpr']) # user_key and cpr are identical in all elements
+		print(user[0]['brugervendtnoegle'])
+		for engagement in user: # An element for each engagement
+		    print(engagement['adresse']['dar-uuid'])
+		    print(engagement['email'])
+		    print(engagement['telefon'])
+		    print('engagement['role']))
+		    print(engagement['association'])
+		    print(engagement['manager'])
+		    print('From: {}. To: {}'.format(engagement['fra'],
+						    engagement['til']))
 
 Importing into MO
 =================
 If the user should want to import the structure into MO, this can be done with the
-script ``populate_mo.py``. Unfortunately, this script does not currently take
-parameters from the command line, the user must manually set the parameters in
-the ``__main__`` part of the code.
+script ``populate_mo.py``.

--- a/os2mo_data_import/fixture_generator/populate_mo.py
+++ b/os2mo_data_import/fixture_generator/populate_mo.py
@@ -1,3 +1,4 @@
+import sys
 from fixture_generator import dummy_data_creator
 from datetime import datetime
 from anytree import PreOrderIter
@@ -271,13 +272,66 @@ class CreateDummyOrg(object):
 
 
 if __name__ == '__main__':
-    importer = ImportHelper(create_defaults=True,
-                            mox_base='http://localhost:5000',
-                            mora_base='http://localhost:80',
-                            system_name="Artificial import",
-                            end_marker="STOP",
-                            store_integration_data=True)
-    creator = CreateDummyOrg(importer, 825, 'Læsø Kommune', scale=1,
-                             org_size=Size.Normal, extra_root=True)
+    if len(sys.argv) == 3:
+        municipality_number = int(sys.argv[1])
+        municipality_name = sys.argv[2]
+        scale = 4
+        mox_base = 'http://localhost:5000'
+        mora_base = 'http://localhost:80'
+        org_size = Size.Normal
+        extra_root = True
 
-    importer.import_all()
+    elif len(sys.argv) == 8:
+        municipality_number = sys.argv[1]
+        municipality_name = sys.argv[2]
+        scale = int(sys.argv[3])
+        org_size_param = sys.argv[4]
+        if org_size_param.lower() == 'small':
+            org_size = Size.Small
+        elif org_size_param.lower() == 'normal':
+            org_size = Size.Normal
+        elif org_size_param.lower() == 'large':
+            org_size = Size.Large
+        else:
+            print('Invalid org size')
+            exit()
+        extra_root = sys.argv[5] == 'True'
+        mox_base = sys.argv[6]
+        mora_base = sys.argv[7]
+    else:
+        print(
+            """
+            This tools needs either 2 or 7 arguments:
+            First two arguments
+            * Municipality number.
+            * Municipality name.
+
+            Five further arguments (either all or none of these should be supplied):
+            * Scale: Scales the number of employees (default 4).
+            * Org size: Small, Normal, Large. If large, multiple employmens will be
+            made for each employee.  If small, only very few units will be created.
+            * Extra root: Add an extra root unit (default True).
+            * mox_base: Default http://localhost:5000
+            * mora_base: Default http://localhost:80
+
+            Example:
+            python3 populate_mo.py 825 "Læsø Kommune" 2 Small True
+            http://localhost:5000 http://localhost:80
+            """
+        )
+        exit()
+
+    importer = ImportHelper(create_defaults=True,
+                            mox_base=mox_base,
+                            mora_base=mora_base,
+                            system_name="Artificial import",
+                            end_marker="STOP_DUMMY",
+                            store_integration_data=True)
+    creator = CreateDummyOrg(importer,
+                             municipality_code=municipality_number,
+                             name=municipality_name,
+                             scale=scale,
+                             org_size=org_size,
+                             extra_root=True)
+
+    # importer.import_all()


### PR DESCRIPTION
populate_mo now takes command line parameters, and thus it is possible to create a dummy_org without modifying the python code.