### PR TITLE
Feature/27687 integration data on details

### DIFF
--- a/os2mo_data_import/import_example.py
+++ b/os2mo_data_import/import_example.py
@@ -1,15 +1,20 @@
 # -- coding: utf-8 --
+import os
 from os2mo_data_import import ImportHelper
 
+MOX_BASE = os.environ.get('MOX_BASE', 'http://localhost:5000')
+MORA_BASE = os.environ.get('MORA_BASE', 'http://localhost:80')
 
-def example_import():
+
+def example_import(mox_base, mora_base):
     """
     Run the example to import the fictional organisation Magenta.
 
     """
 
     # Init
-    os2mo = ImportHelper(create_defaults=True, store_integration_data=True)
+    os2mo = ImportHelper(create_defaults=True, store_integration_data=True,
+                         mox_base=mox_base, mora_base=mora_base)
 
     # The Organisation class is the main entry point,
     # It exposes the related sub classes such as:
@@ -60,9 +65,6 @@ def example_import():
         date_from="1986-01-01",
     )
 
-    # HOTFIX: nested units are failing
-    # This will 'really' be fixed in the refactoring state
-
     # Adding sub units to the example
     os2mo.add_organisation_unit(
         identifier="Sysadmins",
@@ -100,12 +102,12 @@ def example_import():
         user_key="C8EC85B4-A088-434A-B034-CA08A9FD655A",
         title="EAN-nr.",
         scope="EAN",
-        example="00112233"
+        example="1234567890123"
     )
 
     os2mo.add_address_type(
         organisation_unit="Magenta",
-        value="00112233",
+        value="5264144870223",
         type_ref="EAN",
         date_from="1986-01-01",
     )
@@ -445,4 +447,4 @@ def example_import():
 
 
 if __name__ == "__main__":
-    example_import()
+    example_import(MOX_BASE, MORA_BASE)

--- a/os2mo_data_import/long_tests/test_integration_data.py
+++ b/os2mo_data_import/long_tests/test_integration_data.py
@@ -5,6 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
+import os
 import random
 import requests
 import unittest
@@ -19,18 +20,21 @@ from os2mo_data_import import ImportHelper
 from fixture_generator.populate_mo import CreateDummyOrg
 from fixture_generator.populate_mo import Size
 
+MOX_BASE = os.environ.get('MOX_BASE', 'http://localhost:5000')
+MORA_BASE = os.environ.get('MORA_BASE', 'http://localhost:80')
+
 
 class IntegrationDataTests(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         random.seed(1)
         self.morah = MoraHelper(use_cache=False)
-        self.mox_base = 'http://localhost:5000'
-        self.mora_base = 'http://localhost:80'
+        self.mox_base = MOX_BASE
+        self.mora_base = MORA_BASE
         self.system_name = 'Test Dummy Import'
         self.importer = ImportHelper(create_defaults=True,
-                                     mox_base='http://localhost:5000',
-                                     mora_base='http://localhost:80',
+                                     mox_base=self.mox_base,
+                                     mora_base=self.mora_base,
                                      system_name=self.system_name,
                                      end_marker="STOP",
                                      store_integration_data=True)
@@ -62,9 +66,9 @@ class IntegrationDataTests(unittest.TestCase):
         test_values = [
             ('role_count', 5),
             ('association_count', 4),
-            ('engagement_count', 15 + extra_engagement),
+            ('engagement_count', 14 + extra_engagement),
             ('unit_count', 9 + extra_unit),
-            ('manager_count', 5),
+            ('manager_count', 4),
             ('person_count', 20 + extra_employee)
         ]
         for key, value in test_values:

--- a/os2mo_data_import/long_tests/test_multiple_imports.py
+++ b/os2mo_data_import/long_tests/test_multiple_imports.py
@@ -5,6 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
+import os
 import unittest
 
 from . integration_test_helpers import _count
@@ -13,12 +14,15 @@ from freezegun import freeze_time
 from os2mo_data_import import ImportHelper
 from os2mo_helpers.mora_helpers import MoraHelper
 
+MOX_BASE = os.environ.get('MOX_BASE', 'http://localhost:5000')
+MORA_BASE = os.environ.get('MORA_BASE', 'http://localhost:80')
+
 
 class IntegrationDataTests(unittest.TestCase):
     @classmethod
     def setUpClass(self):
-        self.mox_base = 'http://localhost:5000'
-        self.mora_base = 'http://localhost:80'
+        self.mox_base = MOX_BASE
+        self.mora_base = MORA_BASE
         self.system_name = 'Test Dummy Import'
 
         importer = ImportHelper(create_defaults=True,
@@ -47,8 +51,8 @@ class IntegrationDataTests(unittest.TestCase):
     def setUp(self):
         self.morah = MoraHelper(use_cache=False)
         self.importer = ImportHelper(create_defaults=True,
-                                     mox_base='http://localhost:5000',
-                                     mora_base='http://localhost:80',
+                                     mox_base=MOX_BASE,
+                                     mora_base=MORA_BASE,
                                      system_name=self.system_name,
                                      end_marker="STOP",
                                      store_integration_data=True)

--- a/os2mo_data_import/long_tests/test_multiple_imports.py
+++ b/os2mo_data_import/long_tests/test_multiple_imports.py
@@ -26,8 +26,8 @@ class IntegrationDataTests(unittest.TestCase):
         self.system_name = 'Test Dummy Import'
 
         importer = ImportHelper(create_defaults=True,
-                                mox_base='http://localhost:5000',
-                                mora_base='http://localhost:80',
+                                mox_base=MOX_BASE,
+                                mora_base=MORA_BASE,
                                 system_name=self.system_name,
                                 end_marker="STOP",
                                 store_integration_data=True)

--- a/os2mo_data_import/long_tests/test_multiple_imports.py
+++ b/os2mo_data_import/long_tests/test_multiple_imports.py
@@ -13,6 +13,7 @@ from . integration_test_helpers import _count
 from freezegun import freeze_time
 from os2mo_data_import import ImportHelper
 from os2mo_helpers.mora_helpers import MoraHelper
+from integration_abstraction.integration_abstraction import IntegrationAbstraction
 
 MOX_BASE = os.environ.get('MOX_BASE', 'http://localhost:5000')
 MORA_BASE = os.environ.get('MORA_BASE', 'http://localhost:80')
@@ -50,6 +51,7 @@ class IntegrationDataTests(unittest.TestCase):
     @classmethod
     def setUp(self):
         self.morah = MoraHelper(use_cache=False)
+        self.ia = IntegrationAbstraction(MOX_BASE, self.system_name, "STOP")
         self.importer = ImportHelper(create_defaults=True,
                                      mox_base=MOX_BASE,
                                      mora_base=MORA_BASE,
@@ -421,8 +423,6 @@ class IntegrationDataTests(unittest.TestCase):
         )
         self.importer.import_all()
 
-        # Test the user_key is correctly written
-
         count = _count(self.mox_base, at='1980-01-01')
         self.assertTrue(count['person_count'] == 1)
         self.assertTrue(count['engagement_count'] == 0)
@@ -439,8 +439,33 @@ class IntegrationDataTests(unittest.TestCase):
         self.assertTrue(count['person_count'] == 1)
         self.assertTrue(count['engagement_count'] == 1)
 
+    def test_021_test_user_key_and_integration_data(self):
+        """
+        Test the user_key is correctly written.
+        """
+        engagement_list = self.morah.read_user_engagement(
+            '00000000-0000-0000-1000-000000000000',
+            at='2000-01-01'
+        )
+
+        job_ids = {'108', '109'}
+        integration_data = {
+            'e36bd68172e5346c63ffcac5f98300a1f857613a8bc801dd72c7ede6d5de65a2',
+            'ed20aff117c10e4e664cde63215d2eb516a8b7bf5ff9cdd3e31895ddc996fb3d'
+        }
+
+        resource = 'organisation/organisationfunktion'
+        for engagement in engagement_list:
+            job_ids.remove(engagement['user_key'])
+            uuid = engagement['uuid']
+            integration = self.ia.read_integration_data(resource, uuid)
+            integration_data.remove(integration)
+
+        self.assertTrue(len(job_ids) == 0)
+        self.assertTrue(len(integration_data) == 0)
+
     @freeze_time("2018-12-12")
-    def test_021_test_length_of_double_engagements(self):
+    def test_022_test_length_of_double_engagements(self):
         """
         Check change of double engagement, length of one should be independent of
         change of the other
@@ -493,7 +518,7 @@ class IntegrationDataTests(unittest.TestCase):
         self.assertTrue(count['engagement_count'] == 0)
 
     @freeze_time("2018-12-25")
-    def test_022_add_leave_to_user(self):
+    def test_023_add_leave_to_user(self):
         """
         Add a leave to a user.
         Check that the engagement is not stopped when the leave stops.
@@ -525,7 +550,7 @@ class IntegrationDataTests(unittest.TestCase):
         self.assertTrue(count['leave_count'] == 0)
 
     @freeze_time("2019-01-05")
-    def test_023_change_leave(self):
+    def test_024_change_leave(self):
         """
         Add a leave to a user.
         Check that the engagement is not stopped when the leave stops.
@@ -575,7 +600,7 @@ class IntegrationDataTests(unittest.TestCase):
         self.assertTrue(count['leave_count'] == 0)
 
     @freeze_time("2019-01-05")
-    def ttest_024_integration_supported_association_and_role(self):
+    def test_025_integration_supported_association_and_role(self):
         """
         Add a role and and association to employees without adding the  units to the
         importer map.
@@ -612,7 +637,7 @@ class IntegrationDataTests(unittest.TestCase):
         count = _count(self.mox_base, at='2019-01-10')
         self.assertTrue(count['association_count'] == 2)
 
-    def test_025_terminate_employee(self):
+    def test_026_terminate_employee(self):
         """
         Teriminate an employee
         """

--- a/os2mo_data_import/long_tests/test_multiple_imports.py
+++ b/os2mo_data_import/long_tests/test_multiple_imports.py
@@ -447,11 +447,11 @@ class IntegrationDataTests(unittest.TestCase):
             '00000000-0000-0000-1000-000000000000',
             at='2000-01-01'
         )
-
+        
         job_ids = {'108', '109'}
         integration_data = {
-            'e36bd68172e5346c63ffcac5f98300a1f857613a8bc801dd72c7ede6d5de65a2',
-            'ed20aff117c10e4e664cde63215d2eb516a8b7bf5ff9cdd3e31895ddc996fb3d'
+            '5579606a75a36c085affcb6bebb1032ed628ee32a0a60ef5d4649bb63d68f9cd',
+            '2adb36c907c188300808dedb0220fec7217cf901a64492eb0cfbd6ee86964534'
         }
 
         resource = 'organisation/organisationfunktion'

--- a/os2mo_data_import/os2mo_data_import/mora_data_types.py
+++ b/os2mo_data_import/os2mo_data_import/mora_data_types.py
@@ -5,6 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
+import hashlib
 from integration_abstraction.integration_abstraction import IntegrationAbstraction
 
 
@@ -252,6 +253,27 @@ class EngagementType(MoType):
               "uuid": self.org_unit_uuid
         }
 
+
+        # We are not yet at a level, where we are ready to force uuid's on
+        # engagements. Similarly, we do no attempts of sharing engagement objects
+        # between application, currently the integration data support is limiited
+        # to writng a unique key in the identifier for the engagement. For the
+        # same reason, we do not actually bother to obey the store_integrationn_data
+        # setting, the value is just always written.
+        # The unique key is calculated as hash over the individual parts of the
+        # engagement
+        resource = 'organisation/organisationfunktion'
+        hash_value = hashlib.sha256()
+        hash_value.update(self.org_unit_ref.encode('ascii'))
+        hash_value.update(self.type_ref.encode('ascii'))
+        hash_value.update(self.job_function_ref.encode('ascii'))
+
+        self.payload['integration_data'] = self.ia.integration_data_payload(
+            resource,
+            hash_value.hexdigest()
+        )
+
+        
         # Reference the job function uuid
         if not self.job_function_uuid:
             raise ReferenceError("Reference to job function is missing")

--- a/os2mo_data_import/os2mo_data_import/mora_data_types.py
+++ b/os2mo_data_import/os2mo_data_import/mora_data_types.py
@@ -253,7 +253,6 @@ class EngagementType(MoType):
               "uuid": self.org_unit_uuid
         }
 
-
         # We are not yet at a level, where we are ready to force uuid's on
         # engagements. Similarly, we do no attempts of sharing engagement objects
         # between application, currently the integration data support is limiited
@@ -270,9 +269,9 @@ class EngagementType(MoType):
 
         self.payload['integration_data'] = self.ia.integration_data_payload(
             resource,
-            hash_value.hexdigest()
+            hash_value.hexdigest(),
+            encode=False
         )
-
         
         # Reference the job function uuid
         if not self.job_function_uuid:

--- a/os2mo_data_import/os2mo_data_import/mora_data_types.py
+++ b/os2mo_data_import/os2mo_data_import/mora_data_types.py
@@ -266,6 +266,10 @@ class EngagementType(MoType):
         hash_value.update(self.org_unit_ref.encode('ascii'))
         hash_value.update(self.type_ref.encode('ascii'))
         hash_value.update(self.job_function_ref.encode('ascii'))
+        if self.date_from:
+            hash_value.update(self.date_from.encode('ascii'))
+        if self.date_to:
+            hash_value.update(self.date_to.encode('ascii'))
 
         self.payload['integration_data'] = self.ia.integration_data_payload(
             resource,

--- a/os2mo_data_import/os2mo_data_import/utilities.py
+++ b/os2mo_data_import/os2mo_data_import/utilities.py
@@ -843,10 +843,11 @@ class ImportUtility(object):
 
         found_hit = False
         if data_type == 'engagement':
+            # In priciple, we should be able to re-calculate the hash stored in
+            # integration data and compare directly from that.
             for data_item in data[data_type]:
                 if self._std_compare(item_payload, data_item, 'job_function'):
                     found_hit = True
-
         elif data_type == 'role':
             for data_item in data[data_type]:
                 if self._std_compare(item_payload, data_item, 'role_type'):

--- a/os2mo_data_import/os2mo_helpers/mora_helpers.py
+++ b/os2mo_data_import/os2mo_helpers/mora_helpers.py
@@ -164,6 +164,15 @@ class MoraHelper(object):
                 return_address['Adresse'] = address['name']
         return return_address
 
+    def read_user_engagement(self, user, at=None, use_cache=None):
+        """
+        Read engagements for a user.
+        :param user: UUID of the wanted user.
+        :return: List of the users engagements.
+        """
+        engagement = self._mo_lookup(user, 'e/{}/details/engagement', at, use_cache)
+        return engagement
+
     def read_user_address(self, user, username=False, cpr=False,
                           at=None, use_cache=None):
         """ Read phone number and email from user

--- a/os2mo_data_import/tests/test_integration_data_abstraction.py
+++ b/os2mo_data_import/tests/test_integration_data_abstraction.py
@@ -1,8 +1,11 @@
+import os
 import json
 import random
 import unittest
 import requests
 from integration_abstraction import IntegrationAbstraction
+
+MOX_BASE = os.environ.get('MOX_BASE', 'http://localhost:5000')
 
 
 class IntegratioAbstractionTests(unittest.TestCase):


### PR DESCRIPTION
Der er tilføjet support for user_key og integrations_data på engagementer. De øvrige detaljer kan og vil blive tilføjet hvis de bliver relevante. Foreløbig håndterer koden de kendte tilfælde (nemlig job_id) og er forberedt for flere. Der er skrevet tests som verificerer at job_id og integrationsdata skrives korrekt.