### PR TITLE
Feature/28031 ballerup ng

### DIFF
--- a/integrations/ballerup/ballerup.py
+++ b/integrations/ballerup/ballerup.py
@@ -31,10 +31,12 @@ apos_import = apos_importer.AposImport(importer,
                                        MUNICIPALTY_CODE)
 apos_import.create_facetter_and_klasser()
 
+# Org træ
 apos_import.create_ou_tree('b78993bb-d67f-405f-acc0-27653bd8c116')
-sd_enhedstype = '324b8c95-5ff9-439b-a49c-1a6a6bba4651'
-apos_import.create_ou_tree('945bb286-9753-4f77-9082-a67a5d7bdbaf',
-                           enhedstype=sd_enhedstype)
+
+# SD træ
+apos_import.create_ou_tree('945bb286-9753-4f77-9082-a67a5d7bdbaf')
+
 apos_import.create_managers_and_associatins()
 
 importer.import_all()

--- a/integrations/ballerup/ballerup.py
+++ b/integrations/ballerup/ballerup.py
@@ -29,6 +29,7 @@ importer = ImportHelper(create_defaults=True,
 apos_import = apos_importer.AposImport(importer,
                                        MUNICIPALTY_NAME,
                                        MUNICIPALTY_CODE)
+
 apos_import.create_facetter_and_klasser()
 
 # Org træ

--- a/integrations/ballerup/ballerup.sh
+++ b/integrations/ballerup/ballerup.sh
@@ -15,3 +15,4 @@ export MAIN_PHONE_NAME="41504f53-0203-001f-4158-41504f494e54"
 export ALT_PHONE_NAME="7e118f76-2150-4fec-b09f-6428cd05802b"
 
 python3 ballerup.py
+python3 udvalg_import.py

--- a/integrations/ballerup/ballerup.sh
+++ b/integrations/ballerup/ballerup.sh
@@ -7,8 +7,11 @@ export MUNICIPALITY_CODE=151
 export ANSAT_UUID=56e1214a-330f-4592-89f3-ae3ee8d5b2e6
 export BASE_APOS_URL=http://apos.balk.dk:8080/apos2-
 export CREATE_UDVALGS_CLASSES=yes
-export PHONE_NAMES="Alt. Tlf.":"Kontakt Tlf."
-export EMAIL_NAME="E-mail"
-export MAIN_PHONE_NAME="Kontakt Tlf."
+
+export PHONE_NAMES="41504f53-0203-001f-4158-41504f494e54":"7e118f76-2150-4fec-b09f-6428cd05802b"
+
+export EMAIL_NAME="41504f53-0203-0020-4158-41504f494e54"
+export MAIN_PHONE_NAME="41504f53-0203-001f-4158-41504f494e54"
+export ALT_PHONE_NAME="7e118f76-2150-4fec-b09f-6428cd05802b"
 
 python3 ballerup.py


### PR DESCRIPTION
* Fix a stupid bug that broke all DAR addresses
* Fix naming of user-key to fit Ballerups wishes
* Fix 'enhedstype' for the SD tree. This includes a hard-coded replacement table to compensate for a broken relation in the imported system. If more costumers needs the apos importer, this compensation will need to go to configuration. 