### PR TITLE
Feature/28804 surname givenname

### DIFF
--- a/os2mo_data_import/fixture_generator/dummy_data_creator.py
+++ b/os2mo_data_import/fixture_generator/dummy_data_creator.py
@@ -340,7 +340,7 @@ class CreateDummyOrg(object):
             middle = middle + ' ' + self._pick_name_from_list('middle')
 
         last = self._pick_name_from_list('last')
-        name = first + middle + ' ' + last
+        name = (first + middle, last)
         user_key = first + last[0]
         i = 0
         while user_key in self.used_user_keys:
@@ -383,7 +383,8 @@ class CreateDummyOrg(object):
         user = {'fra': time_from,
                 'til': time_to,
                 'brugervendtnoegle': user_key,
-                'brugernavn': name,
+                'givenname': name[0],
+                'surname': name[1],
                 'email': user_key.lower() + '@' + host,
                 'secret_phone': secret_phone[0],
                 'location': location,
@@ -548,20 +549,30 @@ class CreateDummyOrg(object):
                     eng['role'] = self.add_user_func('role_type', node)
 
                 uuid = uuid5(NAMESPACE_DNS, str(random.random()))
-                new_nodes[uuid] = {'name': user[0]['brugernavn'], 'user': user,
-                                   'parent': node}
+                new_nodes[uuid] = {
+                    'givenname': user[0]['givenname'],
+                    'surname': user[0]['surname'],
+                    'user': user,
+                    'parent': node
+                }
 
             # In version one we always add a single manager to a OU
             # This should be randomized and also sometimes be a vacant
             # position
             user = self.create_manager()
             uuid = uuid5(NAMESPACE_DNS, str(random.random()))
-            new_nodes[uuid] = {'name': user[0]['brugernavn'], 'user': user,
-                               'parent': node}
+            new_nodes[uuid] = {
+                'givenname': user[0]['givenname'],
+                'surname': user[0]['surname'],
+                'user': user,
+                'parent': node
+            }
         keys = sorted(new_nodes.keys())
         for key in list(keys):
             user_info = new_nodes[key]
-            user_node = Node(user_info['user'][0]['brugernavn'],
+            user_node = Node(name=user_info['user'][0]['givenname'],
+                             givenname=user_info['user'][0]['givenname'],
+                             surname=user_info['user'][0]['surname'],
                              user=user_info['user'], type='user',
                              parent=user_info['parent'])
             self.nodes[key] = user_node
@@ -586,7 +597,10 @@ if __name__ == '__main__':
         if node.type == 'user':
             print()
             print('---')
-            print(node.name)  # Name of the employee
+            print('Given name: {}, Surname: {}'.format(
+                node.givenname,
+                node.surname
+            ))
             print(node.parent.key)  # Key for parent unit
             user = node.user  # All user information is here
             for engagement in user:

--- a/os2mo_data_import/fixture_generator/populate_mo.py
+++ b/os2mo_data_import/fixture_generator/populate_mo.py
@@ -324,7 +324,8 @@ def main(mox_base, mora_base, municipality, scale, org_size, extra_root):
                             mora_base=mora_base,
                             system_name="Artificial import",
                             end_marker="STOP_DUMMY",
-                            store_integration_data=True)
+                            store_integration_data=True,
+                            seperate_names=False)
 
     CreateDummyOrg(importer,
                    municipality_code=municipality_number,

--- a/os2mo_data_import/fixture_generator/populate_mo.py
+++ b/os2mo_data_import/fixture_generator/populate_mo.py
@@ -76,7 +76,6 @@ class CreateDummyOrg(object):
                                                  predictable_uuids=predictable_uuids)
 
         data.create_org_func_tree(org_size=org_size)
-
         data.add_users_to_tree(scale,
                                multiple_employments=org_size == Size.Large)
         return data
@@ -195,7 +194,7 @@ class CreateDummyOrg(object):
 
     def create_user(self, user_node):
         self.importer.add_employee(
-            name=user_node.name,
+            name=(user_node.user[0]['givenname'], user_node.user[0]['surname']),
             user_key=user_node.user[0]['brugervendtnoegle'],
             identifier=user_node.user[0]['brugervendtnoegle'],
             cpr_no=user_node.user[0]['cpr']

--- a/os2mo_data_import/os2mo_data_import/helpers.py
+++ b/os2mo_data_import/os2mo_data_import/helpers.py
@@ -104,7 +104,9 @@ class ImportHelper(object):
     def __init__(self, system_name="Import", end_marker="_|-STOP",
                  mox_base="http://localhost:8080", mora_base="http://localhost:5000",
                  store_integration_data=False, create_defaults=True,
-                 ImportUtility=ImportUtility):
+                 seperate_names=False, ImportUtility=ImportUtility):
+
+        self.seperate_names = seperate_names
 
         mora_type_config(mox_base=mox_base,
                          system_name=system_name,
@@ -359,8 +361,7 @@ class ImportHelper(object):
         if identifier in self.employees:
             raise ReferenceError("Identifier exists")
 
-        if "name" not in kwargs:
-            kwargs["name"] = identifier
+        kwargs['seperate_names'] = self.seperate_names
 
         self.employees[identifier] = EmployeeType(**kwargs)
         self.employee_details[identifier] = []

--- a/os2mo_data_import/os2mo_data_import/mora_data_types.py
+++ b/os2mo_data_import/os2mo_data_import/mora_data_types.py
@@ -737,7 +737,11 @@ class OrganisationUnitType(MoType):
 
 class EmployeeType(MoType):
     """
-    :param str name: Full name of the employee
+    A MO employee. Either name OR givenname and surname should be supplied.
+    :param str name: Full name of the employee, if type is a tupe with two elements,
+    they will be considered as givenname and surname.
+    :param str givenname: Given name of the employee
+    :param str surname: Surname of the employee
     :param str cpr_no: 10 digit CPR identifier code
     :param str user_key: (Optional) user key for internal reference
     :param str org: Reference to the organisation to which the employee belongs
@@ -749,7 +753,13 @@ class EmployeeType(MoType):
     def __init__(self, name, cpr_no, org=None, uuid=None, user_key=None):
         super().__init__()
 
-        self.name = name
+        if isinstance(name, tuple):
+            self.givenname = name[0]
+            self.surname = name[1]
+        else:
+            self.givenname = name.rsplit(" ", maxsplit=1)[0]
+            self.surname = name[len(self.givenname):].strip()
+            
         self.cpr_no = cpr_no
 
         self.uuid = uuid
@@ -774,11 +784,11 @@ class EmployeeType(MoType):
             raise ReferenceError("UUID of the organisation is missing")
 
         self.payload = {
-            "name": self.name,
+            "givenname": self.givenname,
+            "surname": self.surname,
             "cpr_no": self.cpr_no,
             "org": {
                 "uuid": self.org_uuid
             }
         }
-
         return self._build_payload()

--- a/os2mo_data_import/os2mo_data_import/mora_data_types.py
+++ b/os2mo_data_import/os2mo_data_import/mora_data_types.py
@@ -746,11 +746,10 @@ class EmployeeType(MoType):
     :param str user_key: (Optional) user key for internal reference
     :param str org: Reference to the organisation to which the employee belongs
     :param str/uuid uuid: The object uuid
-    :param str date_from: Start date e.g. "1982-01-01"
-    :param str date_to: End date e.g. "1982-01-01"
     """
 
-    def __init__(self, name, cpr_no, org=None, uuid=None, user_key=None):
+    def __init__(self, name, cpr_no, org=None, uuid=None, user_key=None,
+                 seperate_names=False):
         super().__init__()
 
         if isinstance(name, tuple):
@@ -759,7 +758,8 @@ class EmployeeType(MoType):
         else:
             self.givenname = name.rsplit(" ", maxsplit=1)[0]
             self.surname = name[len(self.givenname):].strip()
-            
+        self.seperate_names = seperate_names
+
         self.cpr_no = cpr_no
 
         self.uuid = uuid
@@ -783,12 +783,21 @@ class EmployeeType(MoType):
         if not self.org_uuid:
             raise ReferenceError("UUID of the organisation is missing")
 
-        self.payload = {
-            "givenname": self.givenname,
-            "surname": self.surname,
-            "cpr_no": self.cpr_no,
-            "org": {
-                "uuid": self.org_uuid
+        if self.seperate_names:
+            self.payload = {
+                "givenname": self.givenname,
+                "surname": self.surname,
+                "cpr_no": self.cpr_no,
+                "org": {
+                    "uuid": self.org_uuid
+                }
             }
-        }
+        else:
+            self.payload = {
+                "name": self.givenname + ' ' + self.surname,
+                "cpr_no": self.cpr_no,
+                "org": {
+                    "uuid": self.org_uuid
+                }
+            }
         return self._build_payload()

--- a/os2mo_data_import/tests/test_dummy_creator.py
+++ b/os2mo_data_import/tests/test_dummy_creator.py
@@ -17,11 +17,12 @@ class DummyTest(unittest.TestCase):
         for i in range(0, 10):
             names.append(self.ddc.create_name(return_user_key=False))
         expected_names = [
-            'Kristine Serup Jørgensen', 'Arne Larsen',
-            'Christian Heldgaard Frederiksen', 'Flemming Lindgaard Skorstengaard',
-            'Maria Ahmednor Brøsted', 'Anders Maagaard Pedersen',
-            'Anne Balsgaard Barløse', 'Margit Hesselbjerg', 'Tina Petersen',
-            'Christen Bødker Weinell'
+            ('Kristine Serup', 'Jørgensen'), ('Arne', 'Larsen'),
+            ('Christian Heldgaard', 'Frederiksen'),
+            ('Flemming Lindgaard', 'Skorstengaard'),
+            ('Maria Ahmednor', 'Brøsted'), ('Anders Maagaard', 'Pedersen'),
+            ('Anne Balsgaard', 'Barløse'), ('Margit', 'Hesselbjerg'),
+            ('Tina', 'Petersen'), ('Christen Bødker', 'Weinell')
         ]
         self.assertEqual(names, expected_names)
 


### PR DESCRIPTION
This PR adds support for assigning separate given names / surnames for user. To maintain compatibility with current releases of MO, a flag has been added to produce old payloads even if separate names has been given as input.

Test are updated. 

The dummey-data creation tool has been updated to use the new importer syntax.