### PR TITLE
trigger-example-module

### DIFF
--- a/triggers/andeby.py
+++ b/triggers/andeby.py
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2017-2018, Magenta ApS
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+"""
+Trigger demonstration module.
+This could be used as a template.
+The imports are the bare minimum for a trigger module
+
+"""
+
+import logging
+from mora import mapping
+from mora.triggers import Trigger
+from mora.service.handlers import RequestType
+
+logger = logging.getLogger("andeby")
+
+
+def andeby_trigger_function(data):
+    """ This is the function that is called with data from the handler module
+    """
+    logger.warning("andeby example called")
+
+
+def register(app):
+    """ Here the function above is registered to get triggered
+        every time an org unit has been terminated
+    """
+    combi = (mapping.ORG_UNIT, RequestType.TERMINATE, Trigger.Event.ON_AFTER)
+    Trigger.on(*combi)(andeby_trigger_function)


### PR DESCRIPTION
Kære Robert: 
Med en mora.json som denne:
```
{
    "TRIGGER_MODULES":[
        "mora.triggers.internal.amqp_trigger",
        "customer.triggers.andeby"
        ]
}
```

Får jeg log som denne:

```
[
16/Aug/2019 09:43:17] "POST /service/validate/org-unit/ HTTP/1.1" 400 -
[16/Aug/2019 09:43:17] "POST /service/validate/org-unit/ HTTP/1.1" 200 -
andeby example called
[16/Aug/2019 09:43:19] "POST /service/ou/ed8a295b-a3be-4b77-9143-1ef3ec3dcd53/terminate HTTP/1.1" 200 -

```
Når jeg har mounted os2mo-data-import-and-export ind i containeren og symlinket til moutet som aftalt.

Med hjælp fra Mathias og Dan er det så lykkedes at tillige at gøre det let at slå dem til og fra individuelt, når der viser sig et behov for det.