### PR TITLE
Feature/29616 write to ad

### DIFF
--- a/integrations/ad_integration/README.rst
+++ b/integrations/ad_integration/README.rst
@@ -111,7 +111,7 @@ oprette AD brugere og skrive information fra MO til relevante felter.
 Hvis denne funktionalitet skal benyttes, er der brug for yderligere parametre som
 skal være sat når programmet afvikles:
 
-* ``AD_SERVERS``: Liste med de DC'ere som findes i kommunens AD. Denne liste anvendes
+ * ``AD_SERVERS``: Liste med de DC'ere som findes i kommunens AD. Denne liste anvendes
   til at sikre at replikering er færdiggjort før der skrives til en nyoprettet
   bruger.
  * ``AD_WRITE_UUID``: Navnet på det felt i AD, hvor MOs bruger-uuid skrives.
@@ -174,9 +174,8 @@ og de relevante af dem synkroniseres til MO. Hvad der er relevant, angives i
 øjeblikket som en hårdkodet liste direkte i synkroniseringsværktøkjet, de nuværende
 eksempeler går alle på forskellige former for adresser.
 
-Da AD ikke understøtter gyldighstider, antages alle informationer uddraget fra AD
+Da AD ikke understøtter gyldighedstider, antages alle informationer uddraget fra AD
 at gælde fra 'i dag' og til evig tid.
-
 
 Synkronisering fra MO til AD foregår efter en algoritme hvor der itereres hen over
 alle AD brugere. Hver enkelt bruger slås op i MO via feltet `AD_WRITE_UUID` og

--- a/integrations/ad_integration/README.rst
+++ b/integrations/ad_integration/README.rst
@@ -112,8 +112,8 @@ Hvis denne funktionalitet skal benyttes, er der brug for yderligere parametre so
 skal være sat når programmet afvikles:
 
  * ``AD_SERVERS``: Liste med de DC'ere som findes i kommunens AD. Denne liste anvendes
-  til at sikre at replikering er færdiggjort før der skrives til en nyoprettet
-  bruger.
+   til at sikre at replikering er færdiggjort før der skrives til en nyoprettet
+   bruger.
  * ``AD_WRITE_UUID``: Navnet på det felt i AD, hvor MOs bruger-uuid skrives.
  * ``AD_WRITE_FORVALTNING``: Navnet på det felt i AD, hvor MO skriver navnet på
    den forvaltning hvor medarbejderen har sin primære ansættelse.
@@ -164,15 +164,15 @@ Synkronisering
 Der eksisterer (udvikles) to synkroniseringstjenester, en til at synkronisere felter
 fra AD til MO, og en til at synkronisere felter fra MO til AD.
 
-Synkronisering fra AD til MO foregår via programmet ``ad_sync.py``. Programmet er i
-vil (for nuværende) i udgangspunktet opdaterere alle relevante værdier i MO fra de
+Synkronisering fra AD til MO foregår via programmet ``ad_sync.py``. Programmet vil
+(for nuværende) i udgangspunktet opdaterere alle relevante værdier i MO fra de
 tilsvarende i AD for alle medarbejdere.
 Dette foregår ved at programmet først udtrækker samtlige medarbejdere fra MO, der
 itereres hen over denne liste, og information fra AD'et slås op med cpr nummer som
 nøgle. Hvis brugeren findes i AD, udlæses alle parametre angivet i ``AD_PROPERTIES``
 og de relevante af dem synkroniseres til MO. Hvad der er relevant, angives i
 øjeblikket som en hårdkodet liste direkte i synkroniseringsværktøkjet, de nuværende
-eksempeler går alle på forskellige former for adresser.
+eksempler går alle på forskellige former for adresser.
 
 Da AD ikke understøtter gyldighedstider, antages alle informationer uddraget fra AD
 at gælde fra 'i dag' og til evig tid.

--- a/integrations/ad_integration/ad_helpers.py
+++ b/integrations/ad_integration/ad_helpers.py
@@ -1,0 +1,45 @@
+import os
+
+import ad_logger
+
+from os2mo_helpers.mora_helpers import MoraHelper
+
+
+MORA_BASE = os.environ.get('MORA_BASE')
+
+
+def find_mo_engagements_without_ad(helper):
+    """"
+    Find a list of all current MO engagements that do not have a valid AD account
+    registred as an IT-system.
+    """
+    org = helper.read_organisation()
+    query = 'o/{}/e?limit=1000000000'
+    employees = helper._mo_lookup(org, query)
+
+    active_users = set()
+    missing_in_ad = set()
+    i = 0
+    for employee in employees['items']:
+        i += 1
+        print('{}/{}'.format(i, len(employees['items'])))
+        uuid = employee['uuid']
+        engagements = helper.read_user_engagement(uuid)
+        if engagements:
+            active_users.add(uuid)
+
+    for employee in active_users:
+        ad_user = helper.get_e_username(employee, 'Active Directory')
+        # Notice: mora_helpers returns an empty string (not None) if no
+        # account is found.
+        if ad_user == '':
+            missing_in_ad.add(employee)
+    return missing_in_ad
+
+
+if __name__ == '__main__':
+    ad_logger.start_logging('ad_helpers.log')
+    helper = MoraHelper(hostname=MORA_BASE, use_cache=False)
+
+    missing_in_ad = find_mo_engagements_without_ad(helper)
+    print(len(missing_in_ad))

--- a/integrations/ad_integration/ad_writer.py
+++ b/integrations/ad_integration/ad_writer.py
@@ -179,12 +179,10 @@ class ADWriter(AD):
             manager = self.helper.read_engagement_manager(engagement['uuid'])
             mo_manager_user = self.helper.read_user(user_uuid=manager['uuid'])
             manager_cpr = mo_manager_user['cpr_no']
-
-            print('Email:')
             manager_mail_dict = self.helper.get_e_address(manager['uuid'],
                                                           scope='EMAIL')
             if manager_mail_dict:
-                manager_mail = manager_mail['value']
+                manager_mail = manager_mail_dict['value']
 
             manager_ad_info = self.get_from_ad(cpr=manager_cpr)
             if len(manager_ad_info) == 1:

--- a/integrations/ad_integration/ad_writer.py
+++ b/integrations/ad_integration/ad_writer.py
@@ -120,7 +120,7 @@ class ADWriter(AD):
             'title': 'Musiker',
             'location': 'Viborg Kommune\Forvalting\Enhed\',
             'forvaltning': 'Beskæftigelse, Økonomi & Personale',
-            'managerSAM': 'DMILL'
+            'manager_sam': 'DMILL'
         }
         """
         logger.info('Read information for {}'.format(uuid))
@@ -174,10 +174,17 @@ class ADWriter(AD):
         location = location[:-1]
 
         manager_sam = None
+        manager_mail = None
         if read_manager:
             manager = self.helper.read_engagement_manager(engagement['uuid'])
             mo_manager_user = self.helper.read_user(user_uuid=manager['uuid'])
             manager_cpr = mo_manager_user['cpr_no']
+
+            print('Email:')
+            manager_mail_dict = self.helper.get_e_address(manager['uuid'],
+                                                          scope='EMAIL')
+            if manager_mail_dict:
+                manager_mail = manager_mail['value']
 
             manager_ad_info = self.get_from_ad(cpr=manager_cpr)
             if len(manager_ad_info) == 1:
@@ -195,7 +202,8 @@ class ADWriter(AD):
             'title': title,
             'location': location,
             'forvaltning': forvaltning,
-            'managerSAM': manager_sam
+            'manager_sam': manager_sam,
+            'manager_mail': manager_mail
         }
         return mo_values
 
@@ -312,12 +320,12 @@ class ADWriter(AD):
 
         if create_manager:
             self._wait_for_replication(sam_account_name)
-            print('Add {} as manager for {}'.format(mo_values['managerSAM'],
+            print('Add {} as manager for {}'.format(mo_values['manager_sam'],
                                                     sam_account_name))
-            logger.info('Add {} as manager for {}'.format(mo_values['managerSAM'],
+            logger.info('Add {} as manager for {}'.format(mo_values['manager_sam'],
                                                           sam_account_name))
             self.add_manager_to_user(user_sam=sam_account_name,
-                                     manager_sam=mo_values['managerSAM'])
+                                     manager_sam=mo_values['manager_sam'])
 
         return (True, sam_account_name)
 

--- a/integrations/ad_integration/ad_writer.py
+++ b/integrations/ad_integration/ad_writer.py
@@ -162,6 +162,8 @@ class ADWriter(AD):
                     end_date = current_end
 
         unit_info = self.helper.read_ou(engagement['org_unit']['uuid'])
+        unit_name = unit_info['name']
+        unit_uuid = unit_info['uuid']
 
         location = ''
         current_unit = unit_info
@@ -200,6 +202,8 @@ class ADWriter(AD):
             'uuid': uuid,
             'cpr': mo_user['cpr_no'],
             'title': title,
+            'unit': unit_name,
+            'unit_uuid': unit_uuid,
             'location': location,
             'forvaltning': forvaltning,
             'manager_name': manager_name,

--- a/integrations/ad_integration/ad_writer.py
+++ b/integrations/ad_integration/ad_writer.py
@@ -173,10 +173,12 @@ class ADWriter(AD):
             current_unit = current_unit['parent']
         location = location[:-1]
 
+        manager_name = None
         manager_sam = None
         manager_mail = None
         if read_manager:
             manager = self.helper.read_engagement_manager(engagement['uuid'])
+            manager_name = manager['Navn']
             mo_manager_user = self.helper.read_user(user_uuid=manager['uuid'])
             manager_cpr = mo_manager_user['cpr_no']
             manager_mail_dict = self.helper.get_e_address(manager['uuid'],
@@ -200,6 +202,7 @@ class ADWriter(AD):
             'title': title,
             'location': location,
             'forvaltning': forvaltning,
+            'manager_name': manager_name,
             'manager_sam': manager_sam,
             'manager_mail': manager_mail
         }

--- a/integrations/ad_integration/ad_writer.py
+++ b/integrations/ad_integration/ad_writer.py
@@ -216,7 +216,7 @@ class ADWriter(AD):
         response = self._run_ps_script(ps_script)
         return response is {}
 
-    def sync_user(self, mo_uuid, user_ad_info=None):
+    def sync_user(self, mo_uuid, user_ad_info=None, sync_manager=True):
         """
         Sync MO information into AD
         """
@@ -251,9 +251,9 @@ class ADWriter(AD):
         response = self._run_ps_script(ps_script)
         logger.debug('Response from sync: {}'.format(response))
 
-        # Works for both create and edit
-        self.add_manager_to_user(user_sam=user_sam,
-                                 manager_sam=mo_values['managerSAM'])
+        if sync_manager:
+            self.add_manager_to_user(user_sam=user_sam,
+                                     manager_sam=mo_values['managerSAM'])
         return (True, 'Sync completed')
 
     def create_user(self, mo_uuid, create_manager, dry_run=False):

--- a/integrations/ad_integration/tests/test_ad_writer.py
+++ b/integrations/ad_integration/tests/test_ad_writer.py
@@ -1,0 +1,150 @@
+# import mock
+import unittest
+
+from ad_writer import ADWriter
+
+test_responses = {}
+
+
+def read_mo_info(uuid, read_manager=True):
+    mo_values = {
+        'name': ('Martin Lee', 'Gore'),
+        'employment_number': '101',
+        'uuid': '7ccbd9aa-gd60-4fa1-4571-0e6f41f6ebc0',
+        'end_date': '2089-11-11',
+        'cpr': '1122334455',
+        'title': 'Musiker',
+        'location': 'Kommune\\Forvalting\\Enhed\\',
+        'forvaltning': 'Beskæftigelse, Økonomi & Personale',
+        'managerSAM': None
+    }
+    if read_manager:
+        mo_values['managerSAM'] = 'DMILL'
+
+    return mo_values
+
+
+def get_from_ad(user=None, cpr=None):
+    return {}
+
+
+def return_ps_script(ps_script):
+    test_responses['ps_script'] = ps_script
+    return {}
+
+
+class TestAdWriter(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        self.ad_writer = ADWriter()
+        self.ad_writer.read_ad_informaion_from_mo = read_mo_info
+        self.ad_writer._run_ps_script = return_ps_script
+        self.ad_writer.get_from_ad = get_from_ad
+
+    def _read_non_common_line(self):
+        script = test_responses['ps_script']
+        script = script.strip()
+        lines = script.split('\n')
+        line = lines[4].strip()  # First four lines are common to all scripts
+        return line
+
+    def test_common_ps_code(self):
+        """
+        Test the first four lines, that are identical for all writes to the AD.
+        Create_user is used as a test-case to provoke the creation of a PS script,
+        but only the common top of the code is actually tested.
+        """
+        self.ad_writer.create_user(mo_uuid='0', create_manager=False)
+        create_script = test_responses['ps_script']
+        create_script = create_script.strip()
+
+        lines = create_script.split('\n')
+
+        self.assertTrue(len(lines) == 5)
+        self.assertTrue(lines[0].find("$User = ") == 0)
+
+        line_one = '$User = '
+        line_two = '$PWord = ConvertTo-SecureString –String'
+        line_three = '$TypeName = "System.Management.Automation.PSCredential"'
+        line_four = ('$UserCredential = New-Object ' +
+                     '–TypeName $TypeName –ArgumentList $User, $PWord')
+
+        self.assertTrue(lines[0].strip().find(line_one) == 0)
+        self.assertTrue(lines[1].strip().find(line_two) == 0)
+        self.assertTrue(lines[2].strip() == line_three)
+        self.assertTrue(lines[3].strip() == line_four)
+
+    def test_create_user_without_manager(self):
+        self.ad_writer.create_user(mo_uuid='0', create_manager=False)
+        create_script = test_responses['ps_script']
+        create_script = create_script.strip()
+
+        lines = create_script.split('\n')
+        line = lines[4]  # First four lines are common to all scripts
+
+        expected_content = [
+            'New-ADUser',
+            '-Name "Martin Lee Gore - MLEGO"',
+            '-Displayname "Martin Lee Gore"',
+            '-GivenName "Martin Lee"',
+            '-SurName "Martin Lee Gore"',
+            '-SamAccountName "MLEGO"',
+            '-EmployeeNumber "101"',
+            '-Credential $usercredential',
+            '"xAutoritativForvaltning"="Beskæftigelse, Økonomi og Personale"',
+            '"xAutoritativOrg"="Kommune\\Forvalting\\Enhed\\"',
+            ';"xSTSBrugerUUID"="7ccbd9aa-gd60-4fa1-4571-0e6f41f6ebc0"',
+            '"xAttrCPR"="1122334455"',
+            '-Path "OU'
+        ]
+
+        for content in expected_content:
+            self.assertTrue(line.find(content) > -1)
+
+    def test_add_manager(self):
+        user = self.ad_writer.read_ad_informaion_from_mo(uuid='0', read_manager=True)
+
+        self.ad_writer.add_manager_to_user('MGORE', manager_sam=user['managerSAM'])
+        manager_script = test_responses['ps_script']
+        manager_script = manager_script.strip()
+        lines = manager_script.split('\n')
+        line = lines[4].strip()  # First four lines are common to all scripts
+
+        expected_line = ("Get-ADUser -Filter 'SamAccountName -eq \"MGORE\"'" +
+                         " -Credential $usercredential |Set-ADUser -Manager DMILL" +
+                         " -Credential $usercredential")
+        self.assertTrue(line == expected_line)
+
+    def test_set_password(self):
+        password = 'password'
+        self.ad_writer.set_user_password('MGORE', password)
+        line = self._read_non_common_line()
+
+        expected_line = (
+            "Get-ADUser -Filter 'SamAccountName -eq \"MGORE\"' -Credential" +
+            " $usercredential |Set-ADAccountPassword -Reset -NewPassword" +
+            " (ConvertTo-SecureString -AsPlainText \"{}\" -Force)" +
+            " -Credential $usercredential"
+        ).format(password)
+        self.assertTrue(line == expected_line)
+
+    def test_sync(self):
+        user_ad_info = {
+            'SamAccountName': 'MGORE'
+        }
+        self.ad_writer.sync_user(mo_uuid='0', user_ad_info=user_ad_info,
+                                 sync_manager=False)
+        line = self._read_non_common_line()
+
+        expected_content = [
+            "Get-ADUser -Filter 'SamAccountName -eq \"MGORE\"' -Credential $usercredential |",
+            'Set-ADUser -Credential $usercredential -Displayname "Martin Lee Gore"',
+            '-GivenName "Martin Lee" -SurName "Martin Lee Gore" -EmployeeNumber \"101\"',
+            "-Replace @{",
+            '"xAutoritativForvaltning"="Beskæftigelse, Økonomi og Personale"',
+            '"xAutoritativOrg"="Kommune\\Forvalting\\Enhed\\"'
+        ]
+
+        for content in expected_content:
+            self.assertTrue(line.find(content) > -1)

--- a/integrations/ad_integration/tests/test_ad_writer.py
+++ b/integrations/ad_integration/tests/test_ad_writer.py
@@ -16,10 +16,12 @@ def read_mo_info(uuid, read_manager=True):
         'title': 'Musiker',
         'location': 'Kommune\\Forvalting\\Enhed\\',
         'forvaltning': 'Beskæftigelse, Økonomi & Personale',
+        'manager_name': None,
         'manager_sam': None,
         'manager_email': None
     }
     if read_manager:
+        mo_values['manager_name'] = 'Daniel Miller'
         mo_values['manager_sam'] = 'DMILL'
         mo_values['manager_email'] = 'dmill@spirit.co.uk'
 

--- a/integrations/ad_integration/tests/test_ad_writer.py
+++ b/integrations/ad_integration/tests/test_ad_writer.py
@@ -16,10 +16,12 @@ def read_mo_info(uuid, read_manager=True):
         'title': 'Musiker',
         'location': 'Kommune\\Forvalting\\Enhed\\',
         'forvaltning': 'Beskæftigelse, Økonomi & Personale',
-        'managerSAM': None
+        'manager_sam': None,
+        'manager_email': None
     }
     if read_manager:
-        mo_values['managerSAM'] = 'DMILL'
+        mo_values['manager_sam'] = 'DMILL'
+        mo_values['manager_email'] = 'dmill@spirit.co.uk'
 
     return mo_values
 
@@ -105,7 +107,7 @@ class TestAdWriter(unittest.TestCase):
     def test_add_manager(self):
         user = self.ad_writer.read_ad_informaion_from_mo(uuid='0', read_manager=True)
 
-        self.ad_writer.add_manager_to_user('MGORE', manager_sam=user['managerSAM'])
+        self.ad_writer.add_manager_to_user('MGORE', manager_sam=user['manager_sam'])
         manager_script = test_responses['ps_script']
         manager_script = manager_script.strip()
         lines = manager_script.split('\n')

--- a/integrations/ad_integration/tests/test_ad_writer.py
+++ b/integrations/ad_integration/tests/test_ad_writer.py
@@ -14,6 +14,8 @@ def read_mo_info(uuid, read_manager=True):
         'end_date': '2089-11-11',
         'cpr': '1122334455',
         'title': 'Musiker',
+        'unit': 'Enhed',
+        'unit_uuid': '101bd9aa-0101-0101-0101-0e6f41f6ebc0',
         'location': 'Kommune\\Forvalting\\Enhed\\',
         'forvaltning': 'Beskæftigelse, Økonomi & Personale',
         'manager_name': None,


### PR DESCRIPTION
Primært indhold i dette PR er de ønskede tests.

Desuden et par rettelser af stavefejl i dokumentation samt første udkast til et værktøj som gennemgår MO for brugere som mangle AD konto.