### PR TITLE
Feature/32241 NYx conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ __pychache__
 venv-*
 venv
 
+#Logs and caches
+tmp
+
 # Workspace
 overflow
 

--- a/integrations/SD_Lon/calculate_primary.py
+++ b/integrations/SD_Lon/calculate_primary.py
@@ -182,7 +182,7 @@ class MOPrimaryEngagementUpdater(object):
             fixed = None
             for eng in mo_engagement:
                 if not eng['engagement_type']:
-                    # Todo: It would seems this happens for leaves, should we make
+                    # Todo: It would seem this happens for leaves, should we make
                     # a special type for this?
                     eng['engagement_type'] = {'uuid': self.eng_types['non_primary']}
 

--- a/integrations/SD_Lon/calculate_primary.py
+++ b/integrations/SD_Lon/calculate_primary.py
@@ -182,6 +182,8 @@ class MOPrimaryEngagementUpdater(object):
             fixed = None
             for eng in mo_engagement:
                 if not eng['engagement_type']:
+                    # Todo: It would seems this happens for leaves, should we make
+                    # a special type for this?
                     eng['engagement_type'] = {'uuid': self.eng_types['non_primary']}
 
                 if eng['engagement_type']['uuid'] == self.eng_types['fixed_primary']:

--- a/integrations/SD_Lon/calculate_primary.py
+++ b/integrations/SD_Lon/calculate_primary.py
@@ -181,6 +181,9 @@ class MOPrimaryEngagementUpdater(object):
 
             fixed = None
             for eng in mo_engagement:
+                if not eng['engagement_type']:
+                    eng['engagement_type'] = {'uuid': self.eng_types['non_primary']}
+
                 if eng['engagement_type']['uuid'] == self.eng_types['fixed_primary']:
                     logger.info('Engagment {} is fixed primary'.format(eng['uuid']))
                     fixed = eng['uuid']
@@ -282,7 +285,7 @@ class MOPrimaryEngagementUpdater(object):
                            help='Check all users for a primary engagement')
         group.add_argument('--recalculate_all', nargs=1,
                            help='Recalculate all all users')
-        group.add_argument('--recalculate_user', nargs=1, metavar='MO uuid',
+        group.add_argument('--recalculate_user', nargs=1, metavar='MO_uuid',
                            help='Recalculate primaries for a user')
 
         args = vars(parser.parse_args())

--- a/integrations/SD_Lon/calculate_primary.py
+++ b/integrations/SD_Lon/calculate_primary.py
@@ -219,6 +219,7 @@ class MOPrimaryEngagementUpdater(object):
                         'validity': validity
                     }
                     payload = sd_payloads.engagement(data, eng)
+                    logger.debug('Status0 edit payload: {}'.format(payload))
                     response = self.helper._mo_post('details/edit', payload)
                     assert response.status_code == 200
                     logger.info('Status0 fixed')

--- a/integrations/SD_Lon/sd_changed_at.py
+++ b/integrations/SD_Lon/sd_changed_at.py
@@ -447,7 +447,7 @@ class ChangeAtSD(object):
             logger.warning('Terminating non-existing job: {}!'.format(job_id))
             return False
 
-        # In MO, the termination date is the late day of work, this
+        # In MO, the termination date is the last day of work,
         # in SD it is the first day of non-work.
         date = datetime.datetime.strptime(from_date, '%Y-%m-%d')
         terminate_datetime = date - datetime.timedelta(days=1)

--- a/integrations/SD_Lon/sd_changed_at.py
+++ b/integrations/SD_Lon/sd_changed_at.py
@@ -723,7 +723,6 @@ class ChangeAtSD(object):
                         logger.warning(
                             'Employment deleted or ended before initial import.'
                         )
-                        continue
                     else:
                         logger.warning('This person should be in MO, but is not')
                         self.update_changed_persons(cpr=cpr)
@@ -733,15 +732,16 @@ class ChangeAtSD(object):
                         )
                         self.updater.set_current_person(mo_person=self.mo_person)
 
-            self.mo_engagement = self.helper.read_user_engagement(
-                self.mo_person['uuid'],
-                read_all=True,
-                only_primary=True,
-                use_cache=False
-            )
-            self._update_user_employments(cpr, sd_engagement)
-            # Re-calculate primary after all updates for user has been performed.
-            self.updater.recalculate_primary()
+            if self.mo_person:
+                self.mo_engagement = self.helper.read_user_engagement(
+                    self.mo_person['uuid'],
+                    read_all=True,
+                    only_primary=True,
+                    use_cache=False
+                )
+                self._update_user_employments(cpr, sd_engagement)
+                # Re-calculate primary after all updates for user has been performed.
+                self.updater.recalculate_primary()
 
 
 def _local_db_insert(insert_tuple):

--- a/integrations/SD_Lon/sd_changed_at.py
+++ b/integrations/SD_Lon/sd_changed_at.py
@@ -160,11 +160,31 @@ class ChangeAtSD(object):
             person_changed = [person_changed]
         return person_changed
 
-    def update_changed_persons(self):
-        # Så vidt vi ved, består person_changed af navn, cpr nummer og ansættelser.
+    def read_person(self, cpr):
+        params = {
+            'EffectiveDate': self.from_date.strftime('%d.%m.%Y'),
+            'PersonCivilRegistrationIdentifier': cpr,
+            'StatusActiveIndicator': 'True',
+            'StatusPassiveIndicator': 'false',
+            'ContactInformationIndicator': 'false',
+            'PostalAddressIndicator': 'false'
+        }
+        url = 'GetPerson20111201'
+        response = sd_common.sd_lookup(url, params=params)
+        person = response.get('Person', [])
+
+        if not isinstance(person, list):
+            person = [person]
+        return person
+
+    def update_changed_persons(self, cpr=None):
         # Ansættelser håndteres af update_employment, så vi tjekker for ændringer i
         # navn og opdaterer disse poster. Nye personer oprettes.
-        person_changed = self.read_person_changed()
+        if cpr is not None:
+            person_changed = self.read_person(cpr)
+        else:
+            person_changed = self.read_person_changed()
+
         logger.info('Number of changed persons: {}'.format(len(person_changed)))
         for person in person_changed:
             cpr = person['PersonCivilRegistrationIdentifier']
@@ -688,12 +708,23 @@ class ChangeAtSD(object):
 
             if not self.mo_person:
                 for employment_info in sd_engagement:
-                    assert (employment_info['EmploymentStatus']
-                            ['EmploymentStatusCode']) in ('S', '7', '8')
-                logger.warning(
-                    'Employment deleted or ended before initial import.'
-                )
-                continue
+                    if (
+                            (employment_info['EmploymentStatus']
+                             ['EmploymentStatusCode'])
+                            in ('S', '7', '8')
+                    ):
+                        logger.warning(
+                            'Employment deleted or ended before initial import.'
+                        )
+                        continue
+                    else:
+                        logger.warning('This person should be in MO, but is not')
+                        self.update_changed_persons(cpr=cpr)
+                        self.mo_person = self.helper.read_user(
+                            user_cpr=cpr,
+                            org_uuid=self.org_uuid
+                        )
+                        self.updater.set_current_person(mo_person=self.mo_person)
 
             self.mo_engagement = self.helper.read_user_engagement(
                 self.mo_person['uuid'],

--- a/integrations/SD_Lon/sd_changed_at.py
+++ b/integrations/SD_Lon/sd_changed_at.py
@@ -446,11 +446,18 @@ class ChangeAtSD(object):
             logger.warning('Terminating non-existing job: {}!'.format(job_id))
             return False
 
+        # In MO, the termination date is the late day of work, this
+        # in SD it is the first day of non-work.
+        date = datetime.datetime.strptime(from_date, '%Y-%m-%d')
+        terminate_datetime = date - datetime.timedelta(days=1)
+        terminate_date = terminate_datetime.strftime('%Y-%m-%d')
+
         payload = {
             'type': 'engagement',
             'uuid': mo_engagement['uuid'],
-            'validity': {'to': from_date}
+            'validity': {'to': terminate_date}
         }
+
         logger.debug('Terminate payload: {}'.format(payload))
         response = self.helper._mo_post('details/terminate', payload)
         logger.debug('Terminate response: {}'.format(response.text))

--- a/integrations/SD_Lon/sd_changed_at.py
+++ b/integrations/SD_Lon/sd_changed_at.py
@@ -1,18 +1,17 @@
 import os
-import sys
+import json
 import logging
+import pathlib
 import sqlite3
 import requests
 import datetime
 import sd_common
 import sd_payloads
 
-from pathlib import Path
-
-from calculate_primary import MOPrimaryEngagementUpdater
+from integrations.SD_Lon.calculate_primary import MOPrimaryEngagementUpdater
 from os2mo_helpers.mora_helpers import MoraHelper
-sys.path.append('../ad_integration')
-import ad_reader
+from integrations.ad_integration import ad_reader
+
 
 LOG_LEVEL = logging.DEBUG
 LOG_FILE = 'mo_integrations.log'
@@ -32,16 +31,19 @@ logging.basicConfig(
     filename=LOG_FILE
 )
 
-MOX_BASE = os.environ.get('MOX_BASE', None)
-MORA_BASE = os.environ.get('MORA_BASE', None)
 RUN_DB = os.environ.get('RUN_DB', None)
 
 
 class ChangeAtSD(object):
     def __init__(self, from_date, to_date=None):
         logger.info('Start ChangedAt: From: {}, To: {}'.format(from_date, to_date))
-        self.mox_base = MOX_BASE
-        self.helper = MoraHelper(hostname=MORA_BASE, use_cache=False)
+        cfg_file = pathlib.Path.cwd() / 'settings' / 'kommune-holstebro.json'
+        if not cfg_file.is_file():
+            raise Exception('No setting file')
+        self.settings = json.loads(cfg_file.read_text())
+
+        self.helper = MoraHelper(hostname=self.settings['mora.base'],
+                                 use_cache=False)
         self.ad_reader = ad_reader.ADParameterReader()
         self.updater = MOPrimaryEngagementUpdater()
         self.from_date = from_date
@@ -84,7 +86,7 @@ class ChangeAtSD(object):
         payload = sd_payloads.profession(profession, self.org_uuid,
                                          self.job_function_facet)
         response = requests.post(
-            url=self.mox_base + '/klassifikation/klasse',
+            url=self.settings['mox.base'] + '/klassifikation/klasse',
             json=payload
         )
         assert response.status_code == 201
@@ -372,8 +374,7 @@ class ChangeAtSD(object):
 
     def apply_NY_logic(self, org_unit, job_id, validity):
         # This must go to sd_common, or some kind of conf
-        too_deep = ['Afdelings-niveau', 'NY1-niveau']
-
+        too_deep = self.settings['integrations.SD_Lon.import.too_deep']
         # Move users and make associations according to NY logic
         ou_info = self.helper.read_ou(org_unit)
         if ou_info['org_unit_type']['name'] in too_deep:
@@ -788,11 +789,11 @@ def initialize_changed_at(from_date, run_db, force=False):
 if __name__ == '__main__':
     logger.info('***************')
     logger.info('Program started')
-    init = False
-    from_date = datetime.datetime(2019, 9, 15, 0, 0)
+    init = True
+    from_date = datetime.datetime(2019, 10, 1, 0, 0)
 
     if init:
-        run_db = Path(RUN_DB)
+        run_db = pathlib.Path(RUN_DB)
         initialize_changed_at(from_date, run_db, force=True)
         exit()
 

--- a/integrations/SD_Lon/sd_common.py
+++ b/integrations/SD_Lon/sd_common.py
@@ -32,7 +32,12 @@ def sd_lookup(url, params={}):
         m.update((str(key) + str(payload[key])).encode())
     m.update(full_url.encode())
     lookup_id = m.hexdigest()
-    cache_file = Path('sd_' + lookup_id + '.p')
+
+    cache_dir = Path('tmp/')
+    if not cache_dir.is_dir():
+        raise Exception('Folder for temporary files does not exist')
+
+    cache_file = Path('tmp/sd_' + lookup_id + '.p')
 
     if cache_file.is_file():
         with open(str(cache_file), 'rb') as f:

--- a/integrations/SD_Lon/sd_importer.py
+++ b/integrations/SD_Lon/sd_importer.py
@@ -361,6 +361,8 @@ class SdImport(object):
         }
         params['EffectiveDate'] = self.import_date
         people = sd_lookup('GetPerson20111201', params)
+        if not isinstance(people['Person'], list):
+            people['Person'] = [people['Person']]
 
         for person in people['Person']:
             cpr = person['PersonCivilRegistrationIdentifier']
@@ -468,10 +470,13 @@ class SdImport(object):
         }
         logger.info('Create emplyoees')
         persons = sd_lookup('GetEmployment20111201', params)
+        if not isinstance(persons['Person'], list):
+            persons['Person'] = [persons['Person']]
         self._create_employees(persons)
 
     def _create_employees(self, persons):
         for person in persons['Person']:
+            logger.debug('Person object to create: {}'.format(person))
             cpr = person['PersonCivilRegistrationIdentifier']
             if cpr[-4:] == '0000':
                 logger.warning('Skipping fictional user: {}'.format(cpr))
@@ -585,6 +590,12 @@ class SdImport(object):
                     date_to = None
                 else:
                     date_to = datetime.datetime.strftime(date_to, "%Y-%m-%d")
+
+                logger.info('Validty for {}: from: {}, to: {}'.format(
+                    employment_id['id'],
+                    date_from,
+                    date_to
+                ))
 
                 # Employees are not allowed to be in these units (allthough
                 # we do make an association). We must instead find the lowest

--- a/integrations/ad_integration/ad_common.py
+++ b/integrations/ad_integration/ad_common.py
@@ -5,8 +5,8 @@ import logging
 from winrm import Session
 from winrm.exceptions import WinRMTransportError
 
-import ad_exceptions
-import read_ad_conf_settings
+from integrations.ad_integration import ad_exceptions
+from integrations.ad_integration import read_ad_conf_settings
 
 logger = logging.getLogger('AdCommon')
 # Is this universal?

--- a/integrations/ad_integration/ad_reader.py
+++ b/integrations/ad_integration/ad_reader.py
@@ -2,11 +2,12 @@ import time
 import pickle
 import logging
 import hashlib
-import read_ad_conf_settings
+
 from pathlib import Path
 from winrm import Session
 
-from ad_common import AD
+from integrations.ad_integration.ad_common import AD
+from integrations.ad_integration import read_ad_conf_settings
 
 logger = logging.getLogger("AdReader")
 
@@ -168,7 +169,6 @@ if __name__ == '__main__':
 
     for user in everything:
         print('Name: {}, Sam: {}, Manger: {}'.format(user['Name'], user['SamAccountName'], user['Manager']))
-        #if user['SamAccountName'] == 'JSTEH':
+        # if user['SamAccountName'] == 'JSTEH':
         #    for key in sorted(user.keys()):
         #        print('{}: {}'.format(key, user[key]))
-

--- a/integrations/dawa_helper.py
+++ b/integrations/dawa_helper.py
@@ -1,6 +1,6 @@
 import pickle
+import pathlib
 import requests
-
 
 def _dawa_request(street_name, postal_code, adgangsadresse=False,
                   skip_letters=False, add_letter=False):
@@ -25,8 +25,12 @@ def _dawa_request(street_name, postal_code, adgangsadresse=False,
     full_url = base + params.format(postal_code, street_name)
     path_url = full_url.replace('/', '_')
 
+    cache_dir = pathlib.Path('tmp/')
+    if not cache_dir.is_dir():
+        raise Exception('Folder for temporary files does not exist')
+    
     try:
-        with open(path_url + '.p', 'rb') as f:
+        with open('tmp/' + path_url + '.p', 'rb') as f:
             response = pickle.load(f)
     except FileNotFoundError:
         response = requests.get(full_url)

--- a/integrations/holstebro/holstebro.py
+++ b/integrations/holstebro/holstebro.py
@@ -3,8 +3,8 @@ import pathlib
 import datetime
 
 from os2mo_data_import import ImportHelper
-import integrations.SD_Lon.sd_importer as sd_importer
-import integrations.ad_integration.ad_reader as ad_reader
+from integrations.SD_Lon import sd_importer
+from integrations.ad_integrations import ad_reader
 
 cfg_file = pathlib.Path.cwd() / 'settings' / 'kommune-holstebro.json'
 if not cfg_file.is_file():

--- a/integrations/holstebro/holstebro.py
+++ b/integrations/holstebro/holstebro.py
@@ -1,28 +1,24 @@
-import os
-import sys
+import json
+import pathlib
 import datetime
 
 from os2mo_data_import import ImportHelper
-sys.path.append('../SD_Lon')
-import sd_importer
+import integrations.SD_Lon.sd_importer as sd_importer
+import integrations.ad_integration.ad_reader as ad_reader
 
-sys.path.append('../ad_integration')
-import ad_reader
+cfg_file = pathlib.Path.cwd() / 'settings' / 'kommune-holstebro.json'
+if not cfg_file.is_file():
+    raise Exception('No setting file')
+settings = json.loads(cfg_file.read_text())
 
-MUNICIPALTY_NAME = os.environ.get('MUNICIPALITY_NAME', 'SD-Løn Import')
-MUNICIPALTY_CODE = os.environ.get('MUNICIPALITY_CODE', 0)
-MOX_BASE = os.environ.get('MOX_BASE')
-MORA_BASE = os.environ.get('MORA_BASE')
-
-GLOBAL_GET_DATE = datetime.datetime(2019, 9, 1, 0, 0)
-
+GLOBAL_GET_DATE = datetime.datetime(2019, 10, 1, 0, 0)
 
 importer = ImportHelper(
     create_defaults=True,
-    mox_base=MOX_BASE,
-    mora_base=MORA_BASE,
-    system_name='SD-Import',
-    end_marker='SDSTOP',
+    mox_base=settings['mox.base'],
+    mora_base=settings['mora.base'],
+    # system_name='SD-Import',
+    # end_marker='SDSTOP',
     store_integration_data=False,
     seperate_names=True
 )
@@ -31,8 +27,7 @@ ad_info_reader = ad_reader.ADParameterReader()
 
 sd = sd_importer.SdImport(
     importer,
-    MUNICIPALTY_NAME,
-    MUNICIPALTY_CODE,
+    settings=settings,
     import_date_from=GLOBAL_GET_DATE,
     ad_info=ad_info_reader
 )
@@ -43,7 +38,6 @@ importer.add_klasse(identifier='IT-Org. Alias',
                     user_key='IT-Org. Alias',
                     scope='TEXT',
                     title='IT-Org. Alias')
-
 
 sd.create_ou_tree(create_orphan_container=True)
 sd.create_employees()

--- a/integrations/holstebro/holstebro.sh
+++ b/integrations/holstebro/holstebro.sh
@@ -1,7 +1,4 @@
-export MUNICIPALITY_NAME='Holstebro Kommune'
-export MUNICIPALITY_CODE=661
+export PYTHONPATH=$PWD:$PYTHONPATH
+script_dir=$(cd $(dirname $0); pwd)
 
-export MOX_BASE=http://localhost:8080
-export MORA_BASE=http://localhost:5000
-
-python3 holstebro.py
+python3 "$script_dir/holstebro.py"

--- a/integrations/viborg/viborg.py
+++ b/integrations/viborg/viborg.py
@@ -6,10 +6,10 @@ import datetime
 from chardet.universaldetector import UniversalDetector
 
 from os2mo_data_import import ImportHelper
-import integrations.SD_Lon.sd_importer as sd_importer
-import integrations.ad_integration.ad_reader as ad_reader
+from integrations.SD_Lon.sd_importer import  sd_importer
+from integrations.ad_integration import ad_reader
 
-cfg_file = pathlib.Path.cwd() / 'settings' / 'kommune-holstebro.json'
+cfg_file = pathlib.Path.cwd() / 'settings' / 'kommune-viborg.json'
 if not cfg_file.is_file():
     raise Exception('No setting file')
 settings = json.loads(cfg_file.read_text())

--- a/integrations/viborg/viborg.py
+++ b/integrations/viborg/viborg.py
@@ -20,7 +20,7 @@ MANAGER_FILE = os.environ.get('MANAGER_FILE')
 # ORIGIN FOR TESTS WIH ACTUAL API
 # GLOBAL_GET_DATE = datetime.datetime(2006, 1, 1, 0, 0) # will not work
 # GLOBAL_GET_DATE = datetime.datetime(2009, 1, 1, 0, 0)
-GLOBAL_GET_DATE = datetime.datetime(2019, 8, 22, 0, 0)
+GLOBAL_GET_DATE = datetime.datetime(2019, 9, 15, 0, 0)
 
 importer = ImportHelper(
     create_defaults=True,
@@ -72,6 +72,13 @@ sd = sd_importer.SdImport(
     ad_info=ad_reader,
     manager_rows=manager_rows
 )
+
+importer.add_klasse(identifier='IT-Org. Alias',
+                    uuid='aa4b3520-4ee9-4ac2-9380-a0da852bb538',
+                    facet_type_ref='org_unit_address_type',
+                    user_key='IT-Org. Alias',
+                    scope='TEXT',
+                    title='IT-Org. Alias')
 
 sd.create_ou_tree(create_orphan_container=False)
 sd.create_employees()

--- a/integrations/viborg/viborg.py
+++ b/integrations/viborg/viborg.py
@@ -1,33 +1,28 @@
 import os
 import csv
-import sys
+import json
+import pathlib
 import datetime
 from chardet.universaldetector import UniversalDetector
 
 from os2mo_data_import import ImportHelper
-sys.path.append('../SD_Lon')
-import sd_importer
+import integrations.SD_Lon.sd_importer as sd_importer
+import integrations.ad_integration.ad_reader as ad_reader
 
-sys.path.append('../ad_integration')
-import ad_reader
+cfg_file = pathlib.Path.cwd() / 'settings' / 'kommune-holstebro.json'
+if not cfg_file.is_file():
+    raise Exception('No setting file')
+settings = json.loads(cfg_file.read_text())
 
-MUNICIPALTY_NAME = os.environ.get('MUNICIPALITY_NAME', 'SD-Løn Import')
-MUNICIPALTY_CODE = os.environ.get('MUNICIPALITY_CODE', 0)
-MOX_BASE = os.environ.get('MOX_BASE', 'http://localhost:8080')
-MORA_BASE = os.environ.get('MORA_BASE', 'http://localhost:80')
 MANAGER_FILE = os.environ.get('MANAGER_FILE')
-
-# ORIGIN FOR TESTS WIH ACTUAL API
-# GLOBAL_GET_DATE = datetime.datetime(2006, 1, 1, 0, 0) # will not work
-# GLOBAL_GET_DATE = datetime.datetime(2009, 1, 1, 0, 0)
 GLOBAL_GET_DATE = datetime.datetime(2019, 9, 15, 0, 0)
 
 importer = ImportHelper(
     create_defaults=True,
-    mox_base=MOX_BASE,
-    mora_base=MORA_BASE,
-    system_name='SD-Import',
-    end_marker='SDSTOP',
+    mox_base=settings['mox.base'],
+    mora_base=settings['mora.base'],
+    # system_name='SD-Import',
+    # end_marker='SDSTOP',
     store_integration_data=False,
     seperate_names=True
 )
@@ -66,8 +61,7 @@ with open(MANAGER_FILE, encoding=encoding) as csvfile:
 
 sd = sd_importer.SdImport(
     importer,
-    MUNICIPALTY_NAME,
-    MUNICIPALTY_CODE,
+    settings=settings,
     import_date_from=GLOBAL_GET_DATE,
     ad_info=ad_reader,
     manager_rows=manager_rows

--- a/integrations/viborg/viborg.sh
+++ b/integrations/viborg/viborg.sh
@@ -1,8 +1,6 @@
-export MUNICIPALITY_NAME='Viborg Kommune'
-export MUNICIPALITY_CODE=791
+export PYTHONPATH=$PWD:$PYTHONPATH
+script_dir=$(cd $(dirname $0); pwd)
 
-export MOX_BASE=http://localhost:8080
-export MORA_BASE=http://localhost:5000
-
+python3 "$script_dir/viborg.py"
 # python3 viborg_without_ad.py
-python3 viborg.py
+


### PR DESCRIPTION
Koden kan nu køres fra roden, læser (visse) settings fra settings/kommune-navn.json og udnytter dette til at tillade lokal konfiguration af værdien af variablen too_deep som bestemmer hvilke enhedsnivauer der tillader ansættelser.