### PR TITLE
allow-running-single-job

### DIFF
--- a/integrations/ad_integration/ad_sync.py
+++ b/integrations/ad_integration/ad_sync.py
@@ -123,7 +123,7 @@ class AdMoSync(object):
             'person': {'uuid': uuid},
             'type': 'address',
             'validity': VALIDITY,
-            'org': self.org
+            'org': {'uuid': self.org}
         }
         if klasse[1] is not None:
             payload['visibility'] = {'uuid': klasse[1]}

--- a/tools/README.rst
+++ b/tools/README.rst
@@ -3,10 +3,11 @@ Tools
 ******************
 Tools indeholder scripts primært beregnet til at køre natlige jobs og restore af data efter fejlede jobs.
 
-Job runner
+Job runner 
 ==========
 Job runner scriptet er ment til at blive kaldt fra crontab på kundens maskiner
 Dets arbejde er:
+
 * at læse konfigurationen  det gøres fra settings/settings.json, som er et symbolsk link til settings-filen for systemet.
 * at køre de prædefinerede dele af nattens cronjob forudsat at de er slået til i konfigurationen
 * at lave en backup af databasen og andre filer, der skal i spil for at få systemet tilbage til en veldefineret tilstand
@@ -24,6 +25,7 @@ Konfigurationen kan se således ud:
         "crontab.RUN_SD_CHANGED_AT": false,
         "crontab.RUN_SD_FIX_DEPARTMENTS": false,
         "crontab.RUN_SD_DB_OVERVIEW": false,
+        "crontab.RUN_AD_SYNC": false,
         "crontab.RUN_MOX_STS_ORGSYNC": false,
         "crontab.RUN_MOX_ROLLE": false,
         "crontab.RUN_CPR_UUID": false,
@@ -48,3 +50,28 @@ file for Rollekatalogseksporten.
 Ideen er at dette script kan kaldes fra cron, finder sin egen konfiguration, kører programmerne, hvorefter det
 laver en backup af ``/path/db-snapshot.sql`` og andre filer, der er nødvendige 
 for at komme tilbage til en veldefineret tilstand.
+
+Der kan være mere konfiguration nødvendig for de enkelte jobs - se disse for detaljer
+
+Afvikling af et enkelt job
+==========================
+
+Det kan, for eksempel under udfikling eller test, være nødvendigt at afvikle en kørsel 'i hånden'
+Den mulighed har man også med job-runner scriptet.  Man giver simpelhen navnet på den indre funktion med i kaldet.
+
+Herefter læses konfiguration på normal vis, men der tages nu ikke hensyn til om jobbet er slået til i konfigurationen eller ej, det køres
+
+Følgende interne funktioner kan kaldes:
+
+* imports_test_ad_connectivity
+* imports_sd_fix_departments
+* imports_sd_changed_at
+* imports_ad_sync
+* exports_mox_rollekatalog
+* exports_mox_stsorgsync
+* reports_sd_db_overview
+* reports_cpr_uuid
+
+Vil man for eksempel afvikle mox_stsorgsync, anvender man kaldet:
+
+    tools/jon-runner.sh exports_mox_stsorgsync

--- a/tools/cron-restore.sh
+++ b/tools/cron-restore.sh
@@ -54,10 +54,15 @@ restore_sd_run_db(){
 
 # restore the map between cpr and uuid
 restore_cpr_mo_ad_map_to_cpr_uuid_map(){
+    echo cpr_mo_ad_map.csv is not restored. You are supposed to always use the latest
+    echo Should the file be missing and You still have a valid database You should create it 
+    echo by running "job-runner.sh reports_cpr_uuid"
+    echo The resulting file should be compared to to settings/cpr_uuid_map.csv
+    echo All lines in cpr_mo_ad_map.csv must be in settings/cpr_uuid_map.csv
     # settings/cpr_uuid_map.csv is the one that is read from during import
     # cpr_mo_ad_map.csv is the one that is written to during export
-    tar -xOf ${bupfile} cpr_mo_ad_map.csv > ${DIPEXAR}/settings/cpr_uuid_map.csv
-    tar -xOf ${bupfile} cpr_mo_ad_map.csv > ${DIPEXAR}/cpr_mo_ad_map.csv
+    # tar -xOf ${bupfile} cpr_mo_ad_map.csv > ${DIPEXAR}/cpr_mo_ad_map-restored.csv
+    :
 }
 
 check_restore_validity || exit 2

--- a/tools/job-runner.sh
+++ b/tools/job-runner.sh
@@ -15,7 +15,7 @@ cd ${DIPEXAR}
 
 # FIXME: remove cache ad pickle files
 # Robert disables them in later ad
-rm -v ad_*.p || :
+rm -v ad_*.p 2>/dev/null || :
 
 export PYTHONPATH=$PWD:$PYTHONPATH
 
@@ -229,4 +229,8 @@ if [ "$#" == "0" ]; then
     echo REPORTS_OK=${REPORTS_OK}
     post_backup
     ) 2>&1 | tee ${CRON_LOG_FILE}
+
+elif [ -n "$(grep $1\(\) $0)" ]; then
+    echo running single job function
+    $1
 fi


### PR DESCRIPTION
Det skal være muligt at bruge job-runneren til at køre en enkelt af funktionerne.
så man fx kan sige: 

`job-runner imports_test_ad_connectivity`