### PR TITLE
Feature/31599 ad mo sync

### DIFF
--- a/integrations/ad_integration/README.rst
+++ b/integrations/ad_integration/README.rst
@@ -330,7 +330,7 @@ anonymieret eksempel på sådan en fil kunne se sådan ud:
    }
 
 
-Hvor betydniningen af de enkelte felter er angviet højere oppe i dokumentationen.
+Hvor betydniningen af de enkelte felter er angivet højere oppe i dokumentationen.
 Felter som omhandler skolemdomænet er foreløbig sat via miljøvariable og er ikke
 inkluderet her, da ingen af skriveintegrationerne på dette tidspunkter undestøtter
 dette.

--- a/integrations/ad_integration/README.rst
+++ b/integrations/ad_integration/README.rst
@@ -250,7 +250,8 @@ sandsynlighed for at man befinder sig i et miljø, hvor dette allerede er på pl
 Punkt 2 gøres ved at oprette filen ``settings.json`` under mappen ``settings`` Et
 anonymieret eksempel på sådan en fil kunne se sådan ud:
 
-::
+.. code-block:: json
+
    {
        "mox.base": "http://localhost:8080",
        "mora.base": "http://localhost:5000",

--- a/integrations/ad_integration/README.rst
+++ b/integrations/ad_integration/README.rst
@@ -32,32 +32,34 @@ med AD bedst afvikles fra et Windows miljø.
 
 For at kunne afvikle integrationen kræves der udover den nævnte opsætning af Keberos,
 at AD er sat op med cpr-numre på medarbejdere samt en servicebruger som har
-rettigheder til at læse dette felt. Desuden skal et antal miljøvariable være sat i
-det miljø integrationen køres fra:
+rettigheder til at læse dette felt. Desuden skal et antal variable være sat i
+``settings.json``
 
 Fælles parametre
 ----------------
 
- * ``WINRM_HOST``: Hostname på remote mangagent server
+ * ``integrations.ad.winrm_host``: Hostname på remote mangagent server
 
 Standard AD
 -----------
 
- * ``AD_SEARCH_BASE``: Search base, eksempelvis 'OU=enheder,DC=kommune,DC=local'
- * ``AD_CPR_FIELD``: Navnet på feltet i AD som indeholder cpr nummer.
- * ``AD_SYSTEM_USER``: Navnet på den systembruger som har rettighed til at læse fra
-   AD.
- * ``AD_PASSWORD``: Password til samme systembruger.
- * ``AD_PROPERTIES``: Liste over felter som skal læses fra AD. Angives som en streng
-   med mellemrum, eks: "xAttrCPR ObjectGuid SamAccountName Title EmailAddress
-   MobilePhone"
+ * ``integrations.ad.search_base``: Search base, eksempelvis
+   'OU=enheder,DC=kommune,DC=local'
+ * ``integrations.ad.cpr_field``: Navnet på feltet i AD som indeholder cpr nummer.
+ * ``integrations.ad.system_user``: Navnet på den systembruger som har rettighed til
+   at læse fra AD.
+ * ``integrations.ad.password``: Password til samme systembruger.
+ * ``integrations.ad.properties``: Liste over felter som skal læses fra AD. Angives
+   som en liste i json-filen.
+
 
 Skole  AD
 ---------
 
 Hvis der ønskes integration til et AD til skoleområdet, udover det almindelige
-administrative AD, skal disse parametre desuden angives. Hvis de ikke er til stede
-ved afviklingen, vil integrationen ikke forsøge at tilgå et skole AD.
+administrative AD, skal disse parametre desuden angives som miljøvariable. Hvis de
+ikke er til stede ved afviklingen, vil integrationen ikke forsøge at tilgå et
+skole AD.
 
  * ``AD_SCHOOL_SEARCH_BASE``
  * ``AD_SCHOOL_CPR_FIELD``
@@ -69,9 +71,24 @@ Test af opsætningen
 -------------------
 
 Der følger med AD integrationen et lille program, ``test_connectivity.py`` som tester
-om der er oprettet de nødvendige Kerberos tokens og miljøvariable.
+om der er oprettet de nødvendige Kerberos tokens og miljøvariable. Programmet
+afvikles med en af to parametre:
 
+ * ``--test-read-settings``
+ * ``--test-write-settings``
 
+En test af læsning foregår i flere trin:
+ * Der testes for om Remote Managent serveren kan nås og autentificeres med et
+   kereros token.
+ * Der testes om det er muligt af afvikle en triviel kommando på AD serveren.
+ * Der testes for, at en søgning på alle cpr-numre fra 31. november returnerer
+   nul resultater.
+ * Der testes for, at en søging på cpr-numre fra den 30. i alle måneder returner
+   mindst et resultat. Hvis der ikke returneres nogen er fejlen efter sandsynligt
+   en manglende rettighed til at læse cpr-nummer feltet.
+ * Der tests om de returnerede svar indeholder mest et eksempel på disse tegn:
+   æ, ø, å, @ som en test af et tegnsættet er korrekt sat op.
+   
 Brug af integrationen
 =====================
 
@@ -98,8 +115,8 @@ returneret.
    # De enkelte opslag går nu direkte til cache og returnerer med det samme
    user = ad_reader.read_user(cpr=cpr, cache_only=True)
 
-Objektet ``user`` vil nu indeholde de felter der er angivet i miljøvariablen
-``AD_PROPERTIES``.
+Objektet ``user`` vil nu indeholde de felter der er angivet i ``settings.json``
+med nøglen ``integrations.ad.properties``.
 
 
 Skrivning til AD
@@ -111,20 +128,22 @@ oprette AD brugere og skrive information fra MO til relevante felter.
 Hvis denne funktionalitet skal benyttes, er der brug for yderligere parametre som
 skal være sat når programmet afvikles:
 
- * ``AD_SERVERS``: Liste med de DC'ere som findes i kommunens AD. Denne liste anvendes
-   til at sikre at replikering er færdiggjort før der skrives til en nyoprettet
-   bruger.
- * ``AD_WRITE_UUID``: Navnet på det felt i AD, hvor MOs bruger-uuid skrives.
- * ``AD_WRITE_FORVALTNING``: Navnet på det felt i AD, hvor MO skriver navnet på
-   den forvaltning hvor medarbejderen har sin primære ansættelse.
- * ``AD_WRITE_ORG``: Navnet på det felt i AD, hvor MO skriver enhedshierakiet for
-   den enhed, hvor medarbejderen har sin primære ansættelse.
- * ``PRIMARY_ENGAGEMENT_TYPES``: Sorteret lister over uuid'er på de ansættelsestyper
-   som markerer en primær ansættelse. Jo tidligere et engagement står i listen, jo
-   mere primært anses det for at være.
- * ``FORVALTNING_TYPE``: uuid på den enhedstype som angiver at enheden er på
-   forvaltingsnieau og derfor skal skrives i feltet angivet i
-   ``AD_WRITE_FORVALTNING``.
+ * ``integrations.ad.write.servers``: Liste med de DC'ere som findes i kommunens AD.
+   Denne liste anvendes til at sikre at replikering er færdiggjort før der skrives
+   til en nyoprettet bruger.
+ * ``integrations.ad.write.uuid_field``: Navnet på det felt i AD, hvor MOs
+   bruger-uuid skrives.
+ * ``integrations.ad.write.forvaltning_field``: Navnet på det felt i AD, hvor MO
+   skriver navnet på den forvaltning hvor medarbejderen har sin primære ansættelse.
+ * ``integrations.ad.write.org_unit_field``: Navnet på det felt i AD, hvor MO
+   skriver enhedshierakiet for den enhed, hvor medarbejderen har sin primære
+   ansættelse.
+ * ``integrations.ad.write.primary_types``: Sorteret lister over uuid'er på de
+   ansættelsestyper som markerer en primær ansættelse. Jo tidligere et engagement
+   står i listen, jo mere primært anses det for at være.
+ * ``integrations.ad.write.forvaltning_type``: uuid på den enhedstype som angiver at
+   enheden er på forvaltingsnieau og derfor skal skrives i feltet angivet i
+   ``integrations.ad.write.forvaltning_field``.
 
 
 Skabelse af brugernavne
@@ -221,53 +240,101 @@ plads i det lokale miljø:
 
  1. En lokal bruger med passende opsætning af kerberos til at kunne tilgå remote
     management serveren.
- 2. De nødvendige miljøvariable med settings.
+ 2. Den nødvendige konfiguration skal angives i ``settings.json``.
  3. Et lokalt pythonmiljø med passende afhængigheder
 
 Angående punkt 1 skal dette opsættes af den lokale IT organisation, hvis man
 har fulgt denne dokumentation så langt som til dette punkt, er der en god
 sandsynlighed for at man befinder sig i et miljø, hvor dette allerede er på plads.
 
-Punkt 2 gøres til lokale tests lettest ved at oprette en shell fil, som opretter de
-nøvdendige miljøvarible.
+Punkt 2 gøres ved at oprette filen ``settings.json`` under mappen ``settings`` Et
+anonymieret eksempel på sådan en fil kunne se sådan ud:
 
 ::
+   {
+       "mox.base": "http://localhost:8080",
+       "mora.base": "http://localhost:5000",
+       "municipality.name": "Kommune Kommune",
+       "municipality.code": 999,
+       "integrations.SD_Lon.import.too_deep": ["Afdelings-niveau"],
+       "integrations.SD_Lon.global_from_date": "2019-10-31",
+       "integrations.SD_Lon.sd_user": "SDUSER",
+       "integrations.SD_Lon.sd_password": "SDPASSWORD",
+       "integrations.SD_Lon.institution_identifier": "AA",
+       "integrations.SD_Lon.import.run_db": "/home/mo/os2mo-data-import-and-export/settings/change_at_runs.db",
+       "address.visibility.secret": "53e9bbec-dd7b-42bd-b7ee-acfbaf8ac28a",
+       "address.visibility.internal": "3fe99cdd-4ab3-4bd1-97ad-2cfb757f3cac",
+       "address.visibility.public": "c5ddc7d6-1cd2-46b0-96de-5bfd88db8d9b",
+       "integrations.ad.winrm_host": "rm_mangement_hostname",
+       "integrations.ad.search_base": "OU=KK,DC=kommune,DC=dk",
+       "integrations.ad.system_user": "serviceuser",
+       "integrations.ad.password": "sericeuser_password",
+       "integrations.ad.cpr_field": "ad_cpr_field",
+       "integrations.ad.write.servers": [
+	   "DC1",
+	   "DC2",
+	   "DC3",
+	   "DC4",
+	   "DC5"
+       ],
+       "integrations.ad.write.forvaltning_type": "cdd1305d-ee6a-45ec-9652-44b2b720395f",
+       "integrations.ad.write.primary_types": [
+	   "62e175e9-9173-4885-994b-9815a712bf42",
+	   "829ad880-c0b7-4f9e-8ef7-c682fb356077",
+	   "35c5804e-a9f8-496e-aa1d-4433cc38eb02"
+       ],
+       "integrations.ad.write.uuid_field": "sts_field",
+       "integrations.ad.write.forvaltning_field": "extensionAttribute1",
+       "integrations.ad.write.org_unit_field": "extensionAttribute2",
+       "integrations.ad.properties": [
+	   "manager",
+	   "ObjectGuid",
+	   "SamAccountName",
+	   "mail",
+	   "mobile",
+	   "pager",
+	   "givenName",
+	   "l",
+	   "sn",
+	   "st",
+	   "cn",
+	   "company",
+	   "title",
+	   "postalCode",
+	   "streetAddress",
+	   "telephoneNumber",
+	   "physicalDeliveryOfficeName",
+	   "extensionAttribute1",
+	   "extensionAttribute2",
+	   "extensionAttribute3",
+	   "extensionAttribute4",
+	   "extensionAttribute5",
+	   "extensionAttribute6",
+	   "extensionAttribute7",
+	   "extensionAttribute9",
+	   "ad_cpr_field"
+       ],
+       "integrations.ad.ad_mo_sync_mapping": {
+	   "user_addresses": {
+	       "telephoneNumber": ["51d4dbaa-cb59-4db0-b9b8-031001ae107d", "PUBLIC"],
+	       "pager": ["956712cd-5cde-4acc-ad0a-7d97c08a95ee", "SECRET"],
+	       "mail": ["c8a49f1b-fb39-4ce3-bdd0-b3b907262db3", null],
+	       "physicalDeliveryOfficeName": ["7ca6dfb1-5cc7-428c-b15f-a27056b90ae5", null],
+	       "mobile": ["43153f5d-e2d3-439f-b608-1afbae91ddf6", "PUBLIC"]
+	   },
+	   "it_systems": {
+	       "samAccountName": "fb2ac325-a1c4-4632-a254-3a7e2184eea7"
+	   }
+       }
+   }
 
-   export AD_SYSTEM_USER=
-   export AD_PASSWORD=
-   export AD_SERVERS=
-   export AD_SEARCH_BASE=
-
-   export AD_WRITE_UUID=
-   export AD_WRITE_FORVALTNING=
-   export AD_WRITE_ORG=
-   export AD_CPR_FIELD=
-   export AD_PROPERTIES=
-
-   export AD_SCHOOL_SYSTEM_USER=""
-   export AD_SCHOOL_PASSWORD=""
-   export AD_SCHOOL_PROPERTIES=""
-
-   export WINRM_HOST=
-
-   export MORA_BASE=http://localhost:5000
-   export MOX_BASE=http://localhost:8080
-   export SAML_TOKEN=
-
-   export VISIBLE_CLASS=''
-   export SECRET_CLASS=''
-   export PRIMARY_ENGAGEMENT_TYPE=
-   export FORVALTNING_TYPE=
 
 Hvor betydniningen af de enkelte felter er angviet højere oppe i dokumentationen.
-Felter som omhandler skolemdomænet er med vilje sat til blanke, da ingen af
-skriveintegrationerne på dette tidspunkter undestøtter dette.
+Felter som omhandler skolemdomænet er foreløbig sat via miljøvariable og er ikke
+inkluderet her, da ingen af skriveintegrationerne på dette tidspunkter undestøtter
+dette.
 
 Når felterne er udfyldt kan indstillingerne effektures med kommandoen:
-
-::
-
-   source <filnavn>
 
 Det skal nu oprettes et lokalt afviklingsmiljø. Dette gøres ved at klone git
 projektet i en lokal mappe og oprette et lokal python miljø:

--- a/integrations/ad_integration/ad_common.py
+++ b/integrations/ad_integration/ad_common.py
@@ -15,7 +15,7 @@ ENCODING = 'cp850'
 
 class AD(object):
     def __init__(self):
-        self.all_settings = read_ad_conf_settings.read_settings_from_env()
+        self.all_settings = read_ad_conf_settings.read_settings()
         if self.all_settings['global']['winrm_host']:
             self.session = Session(
                 'http://{}:5985/wsman'.format(

--- a/integrations/ad_integration/ad_reader.py
+++ b/integrations/ad_integration/ad_reader.py
@@ -13,10 +13,12 @@ logger = logging.getLogger("AdReader")
 
 class ADParameterReader(AD):
 
-    def __init__(self):
+    def __init__(self, skip_school=False):
         super().__init__()
 
         self.all_settings = read_ad_conf_settings.read_settings_from_env()
+        if skip_school:
+            self.all_settings['school']['read_school'] = False
 
         if self.all_settings['global']['winrm_host']:
             self.session = Session(

--- a/integrations/ad_integration/ad_reader.py
+++ b/integrations/ad_integration/ad_reader.py
@@ -16,7 +16,7 @@ class ADParameterReader(AD):
     def __init__(self, skip_school=False):
         super().__init__()
 
-        self.all_settings = read_ad_conf_settings.read_settings_from_env()
+        self.all_settings = read_ad_conf_settings.read_settings()
         if skip_school:
             self.all_settings['school']['read_school'] = False
 

--- a/integrations/ad_integration/ad_sync.py
+++ b/integrations/ad_integration/ad_sync.py
@@ -18,21 +18,6 @@ logger = logging.getLogger('AdSyncRead')
 # There You have it - for example the mobile phone
 # Now You may wonder if the VISIBLE/SECRET are right:
 # Find them here https://os2mo-test.holstebro.dk/service/o/ORGUUID/f/visibility/
-# By the way - this configuration must move to the settings file
-
-# Holstebro
-# mapping = {
-#     'user_addresses': {
-#         'mail': ('49b05fde-cb7a-6fb1-fcf5-59dae4bc647c', None),
-#         'mobile': ('f3abc4f2-c027-f514-a3ba-8cf11b53909a', VISIBLE),
-#         'physicalDeliveryOfficeName': ('377a83ab-57d4-9583-50c8-09753133b8c3', None),
-#         'telephoneNumber': ('0e5b0c70-0c71-a481-5712-7803d0b4cfa0', VISIBLE),
-#         'pager': ('f3abc4f2-c027-f514-a3ba-8cf11b53909a', SECRET)
-#     },
-#     'it_systems': {  # This are not par of AD->MO and could be removed.
-#         'samAccountName': 'aa76fa0e-3cf5-466c-bdaa-60d11d92cf7d'
-#     }
-# }
 
 
 # AD has  no concept of temporality, validity is always from now to infinity.

--- a/integrations/ad_integration/ad_sync.py
+++ b/integrations/ad_integration/ad_sync.py
@@ -1,4 +1,3 @@
-import os
 import json
 import pathlib
 import logging
@@ -11,12 +10,6 @@ from os2mo_helpers.mora_helpers import MoraHelper
 
 logger = logging.getLogger('AdSyncRead')
 
-MORA_BASE = os.environ.get('MORA_BASE')
-VISIBLE = os.environ.get('VISIBLE_CLASS')
-SECRET = os.environ.get('SECRET_CLASS')
-
-if MORA_BASE is None:
-    raise Exception('No address to MO indicated')
 
 # how to check these classes for noobs
 # look at :https://os2mo-test.holstebro.dk/service/o/ORGUUID/f/
@@ -52,14 +45,15 @@ VALIDITY = {
 class AdMoSync(object):
     def __init__(self):
         logger.info('AD Sync Started')
-        self.helper = MoraHelper(hostname=MORA_BASE, use_cache=False)
-        self.org = self.helper.read_organisation()
-
         cfg_file = pathlib.Path.cwd() / 'settings' / 'settings.json'
         if not cfg_file.is_file():
             raise Exception('No setting file')
         self.settings = json.loads(cfg_file.read_text())
         self.mapping = self.settings['integrations.ad.ad_mo_sync_mapping']
+
+        self.helper = MoraHelper(hostname=self.settings['mora.base'],
+                                 use_cache=False)
+        self.org = self.helper.read_organisation()
 
         mo_visibilities = self.helper.read_classes_in_facet('visibility')[0]
         self.visibility = {

--- a/integrations/ad_integration/ad_sync.py
+++ b/integrations/ad_integration/ad_sync.py
@@ -69,7 +69,8 @@ class AdMoSync(object):
             if not found:
                 raise Exception('Error in visibility class configuration')
 
-        self.ad_reader = ad_reader.ADParameterReader()
+        # ad_sync currently does not support school domain.
+        self.ad_reader = ad_reader.ADParameterReader(skip_school=True)
         self.ad_reader.cache_all()
         logger.info('Done with AD caching')
 

--- a/integrations/ad_integration/ad_writer.py
+++ b/integrations/ad_integration/ad_writer.py
@@ -195,11 +195,13 @@ class ADWriter(AD):
             if mail['visibibility']['scope'] == 'SECRET':
                 unit_secure_email = mail['value']
 
-        # TODO: Fall-back if we do not find a dar-address
-        postal_code = re.findall('[0-9]{4}', postal['Adresse'])[0]
-        city_pos = postal['Adresse'].find(postal_code) + 5
-        city = postal['Adresse'][city_pos:]
-        streetname = postal['Adresse'][:city_pos - 7]
+        if postal:
+            postal_code = re.findall('[0-9]{4}', postal['Adresse'])[0]
+            city_pos = postal['Adresse'].find(postal_code) + 5
+            city = postal['Adresse'][city_pos:]
+            streetname = postal['Adresse'][:city_pos - 7]
+        else:
+            postal_code = city = streetname = 'Ukendt'
 
         location = ''
         current_unit = unit_info

--- a/integrations/ad_integration/ad_writer.py
+++ b/integrations/ad_integration/ad_writer.py
@@ -195,6 +195,7 @@ class ADWriter(AD):
             if mail['visibibility']['scope'] == 'SECRET':
                 unit_secure_email = mail['value']
 
+        # TODO: Fall-back if we do not find a dar-address
         postal_code = re.findall('[0-9]{4}', postal['Adresse'])[0]
         city_pos = postal['Adresse'].find(postal_code) + 5
         city = postal['Adresse'][city_pos:]
@@ -233,6 +234,7 @@ class ADWriter(AD):
 
         mo_values = {
             'name': (mo_user['givenname'], mo_user['surname']),
+            'full_name': '{} {}'.format(mo_user['givenname'], mo_user['surname']),
             'employment_number': employment_number,
             'end_date': end_date,
             'uuid': uuid,

--- a/integrations/ad_integration/ad_writer.py
+++ b/integrations/ad_integration/ad_writer.py
@@ -1,4 +1,3 @@
-import os
 import re
 import sys
 import json
@@ -8,7 +7,6 @@ import logging
 import pathlib
 import datetime
 import argparse
-from uuid import UUID
 
 import ad_logger
 import ad_templates
@@ -18,34 +16,7 @@ from ad_common import AD
 from user_names import CreateUserNames
 from os2mo_helpers.mora_helpers import MoraHelper
 
-
 logger = logging.getLogger("AdWriter")
-
-MORA_BASE = os.environ.get('MORA_BASE')
-FORVALTNING_TYPE = os.environ.get('FORVALTNING_TYPE')
-PRIMARY_ENGAGEMENT_LIST = os.environ.get('PRIMARY_ENGAGEMENT_TYPES', '')
-
-SETTINGS_FILE = os.environ.get('SETTINGS_FILE')
-if not SETTINGS_FILE:
-    raise Exception('Settings file not set in enironment')
-
-
-# These checks could in principle go to a common configuration checker
-if not PRIMARY_ENGAGEMENT_LIST == '':
-    PRIMARY_ENGAGEMENT_TYPES = PRIMARY_ENGAGEMENT_LIST.split(' ')
-else:
-    msg = 'Configuration error: MORA_BASE: {}, PRIMARY_ENGAGEMENT_TYPE: {}'
-    raise Exception(msg.format(MORA_BASE, PRIMARY_ENGAGEMENT_LIST))
-
-for prim_eng in PRIMARY_ENGAGEMENT_TYPES:
-    try:
-        UUID(prim_eng, version=4)
-    except ValueError:
-        raise Exception('Illegal uuid in primary engagement list')
-
-if MORA_BASE is None:
-    msg = 'Configuration error: MORA_BASE: {}, PRIMARY_ENGAGEMENT_TYPE: {}'
-    raise Exception(msg.format(MORA_BASE, PRIMARY_ENGAGEMENT_TYPES))
 
 
 def _random_password(length=12):
@@ -59,13 +30,14 @@ class ADWriter(AD):
     def __init__(self):
         super().__init__()
 
-        cfg_file = pathlib.Path.cwd() / 'settings' / SETTINGS_FILE
+        cfg_file = pathlib.Path.cwd() / 'settings' / 'settings.json'
         if not cfg_file.is_file():
             raise Exception('No setting file')
         self.settings = json.loads(cfg_file.read_text())
+        self.pet = self.settings['integrations.ad.write.primary_types']
 
-        self.pet = PRIMARY_ENGAGEMENT_TYPES
-        self.helper = MoraHelper(hostname=MORA_BASE, use_cache=False)
+        self.helper = MoraHelper(hostname=self.settings['mora.base'],
+                                 use_cache=False)
         self.name_creator = CreateUserNames(occupied_names=set())
         logger.info('Reading occupied names')
         self.name_creator.populate_occupied_names()
@@ -189,7 +161,7 @@ class ADWriter(AD):
         # Now, calculate final end date for any primary engagement
         future_engagements = self.helper.read_user_engagement(uuid, read_all=True)
         for eng in future_engagements:
-            if engagement['engagement_type']['uuid'] in PRIMARY_ENGAGEMENT_TYPES:
+            if engagement['engagement_type']['uuid'] in self.pet:
                 current_end = eng['validity']['to']
                 if current_end is None:
                     current_end = '9999-12-31'
@@ -233,7 +205,8 @@ class ADWriter(AD):
         forvaltning = 'Ingen'
         while current_unit:
             location = current_unit['name'] + '\\' + location
-            if current_unit['org_unit_type']['uuid'] == FORVALTNING_TYPE:
+            if current_unit['org_unit_type']['uuid'] == self.settings[
+                    'integrations.ad.write.forvaltning_type']:
                 forvaltning = current_unit['name']
             current_unit = current_unit['parent']
         location = location[:-1]
@@ -477,7 +450,7 @@ class ADWriter(AD):
         Command line interface for the AD writer class.
         """
         parser = argparse.ArgumentParser(description='AD Writer')
-        group = parser.add_mutually_exclusive_group()
+        group = parser.add_mutually_exclusive_group(required=True)
         group.add_argument('--create-user-with-manager', nargs=1, metavar='MO_uuid',
                            help='Create a new user in AD, also assign a manager')
         group.add_argument('--create-user', nargs=1, metavar='MO_uuid',

--- a/integrations/ad_integration/read_ad_conf_settings.py
+++ b/integrations/ad_integration/read_ad_conf_settings.py
@@ -78,6 +78,21 @@ def _read_primary_write_information():
     # Field for the path to the users unit
     primary_write_settings['org_field'] = SETTINGS.get(
         'integrations.ad.write.org_unit_field')
+
+    # Ordered list of primary engagements
+    # This is technically speaking not used in this context, but it is needed for
+    # AD write and can benifit from the automated check.
+    # TODO: Some happy day, we could check for the actual validity of these
+    primary_write_settings['primary_types'] = SETTINGS.get(
+        'integrations.ad.write.primary_types')
+
+    # UUID for the unit type considered to be 'Forvaltning'
+    # This is technically speaking not used in this context, but it is needed for
+    # AD write and can benifit from the automated check.
+    # TODO: Some happy day, we could check for the actual validity of these
+    primary_write_settings['forvaltning_type'] = SETTINGS.get(
+        'integrations.ad.write.forvaltning_type')
+
     missing = []
 
     for key, val in primary_write_settings.items():

--- a/integrations/ad_integration/read_ad_conf_settings.py
+++ b/integrations/ad_integration/read_ad_conf_settings.py
@@ -83,7 +83,7 @@ def _read_primary_write_information():
             missing.append(key)
     if missing:
         msg = 'Missing values for AD write {}'.format(missing)
-        logger.error(msg)
+        logger.info(msg)
         primary_write_settings = {}
 
     return primary_write_settings
@@ -123,7 +123,7 @@ def _read_school_ad_settings():
     return school_settings
 
 
-def read_settings_from_env():
+def read_settings():
     settings = {}
     settings['global'] = _read_global_settings()
     settings['primary'] = _read_primary_ad_settings()

--- a/integrations/ad_integration/read_ad_conf_settings.py
+++ b/integrations/ad_integration/read_ad_conf_settings.py
@@ -35,16 +35,11 @@ def _read_global_settings():
 
 def _read_primary_ad_settings():
     primary_settings = {}
-
-    primary_settings['search_base'] = os.environ.get('AD_SEARCH_BASE')
-    primary_settings['cpr_field'] = os.environ.get('AD_CPR_FIELD')
-    primary_settings['system_user'] = os.environ.get('AD_SYSTEM_USER')
-    primary_settings['password'] = os.environ.get('AD_PASSWORD')
-    ad_properties_raw = os.environ.get('AD_PROPERTIES')
-    if ad_properties_raw:
-        primary_settings['properties'] = set(ad_properties_raw.split(' '))
-    else:
-        primary_settings['properties'] = None
+    primary_settings['search_base'] = SETTINGS.get('integrations.ad.search_base')
+    primary_settings['cpr_field'] = SETTINGS.get('integrations.ad.cpr_field')
+    primary_settings['system_user'] = SETTINGS.get('integrations.ad.system_user')
+    primary_settings['password'] = SETTINGS.get('integrations.ad.password')
+    primary_settings['properties'] = SETTINGS.get('integrations.ad.properties')
 
     missing = []
     for key, val in primary_settings.items():

--- a/integrations/ad_integration/read_ad_conf_settings.py
+++ b/integrations/ad_integration/read_ad_conf_settings.py
@@ -1,7 +1,19 @@
 import os
+import json
+import pathlib
 import logging
 
 logger = logging.getLogger("AdReader")
+
+
+# TODO: Soon we have done this 4 times. Should we make a small settings
+# importer, that will also handle datatype for specicic keys?
+cfg_file = pathlib.Path.cwd() / 'settings' / 'settings.json'
+if not cfg_file.is_file():
+    raise Exception('No setting file')
+# TODO: This must be clean up, settings should be loaded by __init__
+# and no references should be needed in global scope.
+SETTINGS = json.loads(cfg_file.read_text())
 
 
 def _read_global_settings():
@@ -12,8 +24,8 @@ def _read_global_settings():
         global_settings['servers'] = set(ad_servers_raw.split(' '))
     else:
         global_settings['servers'] = None
-    
-    global_settings['winrm_host'] = os.environ.get('WINRM_HOST')
+
+    global_settings['winrm_host'] = SETTINGS.get('integrations.ad.winrm_host')
     if not global_settings['winrm_host']:
         msg = 'Missing hostname for remote management server'
         logger.error(msg)

--- a/integrations/ad_integration/read_ad_conf_settings.py
+++ b/integrations/ad_integration/read_ad_conf_settings.py
@@ -19,12 +19,7 @@ SETTINGS = json.loads(cfg_file.read_text())
 def _read_global_settings():
     global_settings = {}
 
-    ad_servers_raw = os.environ.get('AD_SERVERS')
-    if ad_servers_raw:
-        global_settings['servers'] = set(ad_servers_raw.split(' '))
-    else:
-        global_settings['servers'] = None
-
+    global_settings['servers'] = SETTINGS.get('integrations.ad.write.servers')
     global_settings['winrm_host'] = SETTINGS.get('integrations.ad.winrm_host')
     if not global_settings['winrm_host']:
         msg = 'Missing hostname for remote management server'
@@ -51,11 +46,14 @@ def _read_primary_ad_settings():
         raise Exception(msg)
 
     # Settings that do not need to be set, or have defaults
-    primary_settings['server'] = os.environ.get('AD_SERVER')
+    # Most likely the correct value is always None
+    # primary_settings['server'] = os.environ.get('AD_SERVER')
+    primary_settings['server'] = None
 
     # So far false in all known cases, default to false
-    get_ad_object = os.environ.get('AD_GET_AD_OBJECT', 'False')
-    primary_settings['get_ad_object'] = get_ad_object.lower() == 'true'
+    # get_ad_object = os.environ.get('AD_GET_AD_OBJECT', 'False')
+    # primary_settings['get_ad_object'] = get_ad_object.lower() == 'true'
+    primary_settings['get_ad_object'] = False
     return primary_settings
 
 
@@ -67,17 +65,21 @@ def _read_primary_write_information():
     primary_write_settings = {}
 
     # Shared with read
-    primary_write_settings['cpr_field'] = os.environ.get('AD_CPR_FIELD')
+    primary_write_settings['cpr_field'] = SETTINGS.get('integrations.ad.cpr_field')
 
     # Field for writing the uuid of a user, used to sync to STS
-    primary_write_settings['uuid_field'] = os.environ.get('AD_WRITE_UUID')
+    primary_write_settings['uuid_field'] = SETTINGS.get(
+        'integrations.ad.write.uuid_field')
 
     # Field for writing the name of the users 'forvaltning'
-    primary_write_settings['forvaltning_field'] = os.environ.get('AD_WRITE_FORVALTNING')
+    primary_write_settings['forvaltning_field'] = SETTINGS.get(
+        'integrations.ad.write.forvaltning_field')
 
     # Field for the path to the users unit
-    primary_write_settings['org_field'] = os.environ.get('AD_WRITE_ORG')
+    primary_write_settings['org_field'] = SETTINGS.get(
+        'integrations.ad.write.org_unit_field')
     missing = []
+
     for key, val in primary_write_settings.items():
         if not val:
             missing.append(key)
@@ -85,7 +87,6 @@ def _read_primary_write_information():
         msg = 'Missing values for AD write {}'.format(missing)
         logger.info(msg)
         primary_write_settings = {}
-
     return primary_write_settings
 
 

--- a/integrations/ad_integration/test_connectivity.py
+++ b/integrations/ad_integration/test_connectivity.py
@@ -1,6 +1,6 @@
 import json
 import pathlib
-# from kerberos import GSSError
+import argparse
 import requests_kerberos
 from winrm import Session
 
@@ -91,17 +91,27 @@ def test_full_ad_read():
     return True
 
 
-def perform_test():
+def test_ad_write_settings():
+    from integrations.ad_integration import read_ad_conf_settings
+    all_settings = read_ad_conf_settings.read_settings()
+    if not all_settings['primary_write']:
+        return False
+
+
+def perform_read_test():
+    print('Test basic connectivity (Kerberos)')
     basic_connection = test_basic_connectivity()
     if not basic_connection:
         print('Unable to connect to management server')
         exit(1)
 
+    print('Test AD contact')
     ad_connection = test_ad_contact()
     if not ad_connection:
         print('Unable to connect to AD')
         exit(1)
 
+    print('Test ability to read from AD')
     full_ad_read = test_full_ad_read()
     if not full_ad_read:
         print('Unable to read users from AD correctly')
@@ -110,5 +120,37 @@ def perform_test():
     print('Success')
     exit(0)
 
+
+def perform_write_test():
+    print('Test that AD write settings are set up')
+    write_settings = test_ad_write_settings()
+    if not write_settings:
+        print('Write settings not correctly set up')
+        exit(1)
+
+    # TODO: If we could make a test write, it would be nice.
+
+    print('Success')
+    exit(0)
+
+
+def cli():
+        """
+        Command line interface for the AD writer class.
+        """
+        parser = argparse.ArgumentParser(description='AD Writer')
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument('--test-read-settings', action='store_true')
+        group.add_argument('--test-write-settings', action='store_true')
+
+        args = vars(parser.parse_args())
+
+        if args.get('test_read_settings'):
+            perform_read_test()
+
+        if args.get('test_write_settings'):
+            perform_write_test()
+
 if __name__ == '__main__':
-    perform_test()
+    # perform_read_test()
+    cli()

--- a/integrations/ad_integration/test_connectivity.py
+++ b/integrations/ad_integration/test_connectivity.py
@@ -155,5 +155,4 @@ def cli():
 
 
 if __name__ == '__main__':
-    # perform_read_test()
     cli()

--- a/integrations/ad_integration/test_connectivity.py
+++ b/integrations/ad_integration/test_connectivity.py
@@ -1,10 +1,19 @@
-import os
+import json
+import pathlib
 # from kerberos import GSSError
 import requests_kerberos
 from winrm import Session
 
 
-WINRM_HOST = os.environ.get('WINRM_HOST', None)
+# TODO: Soon we have done this 4 times. Should we make a small settings
+# importer, that will also handle datatype for specicic keys?
+cfg_file = pathlib.Path.cwd() / 'settings' / 'settings.json'
+if not cfg_file.is_file():
+    raise Exception('No setting file')
+# TODO: This must be clean up, settings should be loaded by __init__
+# and no references should be needed in global scope.
+SETTINGS = json.loads(cfg_file.read_text())
+WINRM_HOST = SETTINGS.get('integrations.ad.winrm_host')
 if not (WINRM_HOST):
     raise Exception('WINRM_HOST is missing')
 

--- a/integrations/ad_integration/test_connectivity.py
+++ b/integrations/ad_integration/test_connectivity.py
@@ -65,9 +65,9 @@ def test_full_ad_read():
         print('Found users with bithday 31. November!')
         return False
 
-    ad_reader.uncached_read_user(cpr='301*')
+    ad_reader.uncached_read_user(cpr='30*')
     if not ad_reader.results:
-        print('No users found with bithday 30. October, November or December!')
+        print('No users found with bithday on the 30th of any month!')
         return False
 
     test_chars = {
@@ -135,21 +135,22 @@ def perform_write_test():
 
 
 def cli():
-        """
-        Command line interface for the AD writer class.
-        """
-        parser = argparse.ArgumentParser(description='AD Writer')
-        group = parser.add_mutually_exclusive_group()
-        group.add_argument('--test-read-settings', action='store_true')
-        group.add_argument('--test-write-settings', action='store_true')
+    """
+    Command line interface for the AD writer class.
+    """
+    parser = argparse.ArgumentParser(description='AD Writer')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--test-read-settings', action='store_true')
+    group.add_argument('--test-write-settings', action='store_true')
 
-        args = vars(parser.parse_args())
+    args = vars(parser.parse_args())
 
-        if args.get('test_read_settings'):
-            perform_read_test()
+    if args.get('test_read_settings'):
+        perform_read_test()
 
-        if args.get('test_write_settings'):
-            perform_write_test()
+    if args.get('test_write_settings'):
+        perform_write_test()
+
 
 if __name__ == '__main__':
     # perform_read_test()

--- a/integrations/ad_integration/test_connectivity.py
+++ b/integrations/ad_integration/test_connectivity.py
@@ -96,6 +96,8 @@ def test_ad_write_settings():
     all_settings = read_ad_conf_settings.read_settings()
     if not all_settings['primary_write']:
         return False
+    else:
+        return True
 
 
 def perform_read_test():
@@ -139,7 +141,7 @@ def cli():
     Command line interface for the AD writer class.
     """
     parser = argparse.ArgumentParser(description='AD Writer')
-    group = parser.add_mutually_exclusive_group()
+    group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--test-read-settings', action='store_true')
     group.add_argument('--test-write-settings', action='store_true')
 

--- a/integrations/ad_integration/test_connectivity.py
+++ b/integrations/ad_integration/test_connectivity.py
@@ -52,19 +52,63 @@ def test_ad_contact():
         return False
 
 
+def test_full_ad_read():
+    """
+    Test that we can read actual users from AD. This ensures suitable rights
+    to access cpr-information in AD.
+    """
+    from ad_reader import ADParameterReader
+    ad_reader = ADParameterReader()
+
+    ad_reader.uncached_read_user(cpr='3111*')
+    if ad_reader.results:
+        print('Found users with bithday 31. November!')
+        return False
+
+    ad_reader.uncached_read_user(cpr='301*')
+    if not ad_reader.results:
+        print('No users found with bithday 30. October, November or December!')
+        return False
+
+    test_chars = {
+        'æ': False,
+        'ø': False,
+        'å': False,
+        '@': False
+    }
+    for user in ad_reader.results.values():
+        for value in user.values():
+            for char in test_chars.keys():
+                if str(value).find(char) > -1:
+                    test_chars[char] = True
+
+    for test_value in test_chars.values():
+        if not test_value:
+            print('Did find any occurances of special char: {}'.format(test_chars))
+            print('(all should be True for success)')
+            return False
+
+    return True
+
+
 def perform_test():
     basic_connection = test_basic_connectivity()
     if not basic_connection:
         print('Unable to connect to management server')
-        exit()
+        exit(1)
 
     ad_connection = test_ad_contact()
     if not ad_connection:
         print('Unable to connect to AD')
-        exit()
+        exit(1)
+
+    full_ad_read = test_full_ad_read()
+    if not full_ad_read:
+        print('Unable to read users from AD correctly')
+        exit(1)
 
     print('Success')
-
+    exit(0)
 
 if __name__ == '__main__':
     perform_test()


### PR DESCRIPTION
**Oprydning i AD koden.**
Fjerner alt brug af pickle-filer.
Kraftig reduktion i antallet af miljøvariable (kun skoledomænet er tilbage)
Opdateret dokumentation
Stærkt forbedret AD->MO synkronisering
Forbedring af test_connectivity.py så den nu tester om vi har rettigheder til at læse cpr