### PR TITLE
Feature/34282 from scool ad

### DIFF
--- a/integrations/ad_integration/README.rst
+++ b/integrations/ad_integration/README.rst
@@ -182,18 +182,59 @@ Synkronisering
 Der eksisterer (udvikles) to synkroniseringstjenester, en til at synkronisere felter
 fra AD til MO, og en til at synkronisere felter fra MO til AD.
 
-Synkronisering fra AD til MO foregår via programmet ``ad_sync.py``. Programmet vil
-(for nuværende) i udgangspunktet opdaterere alle relevante værdier i MO fra de
-tilsvarende i AD for alle medarbejdere.
-Dette foregår ved at programmet først udtrækker samtlige medarbejdere fra MO, der
-itereres hen over denne liste, og information fra AD'et slås op med cpr nummer som
-nøgle. Hvis brugeren findes i AD, udlæses alle parametre angivet i ``AD_PROPERTIES``
-og de relevante af dem synkroniseres til MO. Hvad der er relevant, angives i
-øjeblikket som en hårdkodet liste direkte i synkroniseringsværktøkjet, de nuværende
-eksempler går alle på forskellige former for adresser.
+AD til MO
++++++++++
+
+Synkronisering fra AD til MO foregår via programmet ``ad_sync.py``.
+
+Programmet opdaterer alle værdier i MO i henhold til den feltmapning som er angivet
+i `settings.json`. Det er muligt at synkronisere adresseoplysninger, samt at
+oprette et IT-system på brugeren, hvis brugeren findes i AD, men endnu ikke har et
+tilknyttet IT-system i MO. Et eksempel på en feltmapning angives herunder:
+
+.. code-block:: json
+
+    "integrations.ad.ad_mo_sync_mapping": {
+	"user_addresses": {
+	    "telephoneNumber": ["a6dbb837-5fca-4f05-b369-8476a35e0a95", "INTERNAL"],
+	    "pager": ["d9cd7a04-a992-4b31-9534-f375eba2f1f4 ", "PUBLIC"],
+	    "EmailAddress": ["fbd70da1-ad2e-4373-bb4f-2a431b308bf1", null],
+	    "mobile": ["6e7131a0-de91-4346-8607-9da1b576fc2a ", "PUBLIC"]
+	},
+	"it_systems": {
+	    "samAccountName": "d2998fa8-9d0f-4a2c-b80e-c754c72ef094"
+	}
+    }
+
+For adresser angives en synlighed, som kan antage værdien `PUBLIC`, `INTERNAL`,
+`SECRET` eller `null` som angiver henholdsvis at synligheden i MO sættes til
+henholdsvis offentlig, intern, hemmelig, eller ikke angivet. UUID'er er på
+de tilhørende adresseklasser i MO som AD felterne skal mappes til.
+
+Hvis der for en given bruger er felter i feltmapningen som ikke findes i AD, vil
+disse felter bliver sprunget over, men de øvrige felter vil stadig blive
+sykroniseret.
+
+Selve synkroniseringen foregår ved at programmet først udtrækker samtlige
+medarbejdere fra MO, der itereres hen over denne liste, og information fra AD'et
+slås op med cpr-nummer som nøgle. Hvis brugeren findes i AD, udlæses alle parametre
+angivet i ``AD_PROPERTIES`` og de af dem som figurerer i feltmapningen synkroniseres
+til MO.
+
+Integrationen vil som udgangspunkt ikke synkronisere fra et eventuelt skole AD, med
+mindre nøglen `integrations.ad.skip_school_ad_to_mo` sættes til `false`.
 
 Da AD ikke understøtter gyldighedstider, antages alle informationer uddraget fra AD
 at gælde fra 'i dag' og til evig tid.
+
+Slutteligt skal det nævnes, at implemeneringen af synkroniseringen understøtter
+muligheden for at opnå en betydelig hastighedsforbering ved at tillade direkte adgang
+til LoRa, denne funktion aktiveres med nøglen
+`integrations.ad.ad_mo_sync_direct_lora_speedup` og reducerer kørselstiden med ca.
+50%.
+
+MO til AD
++++++++++
 
 Synkronisering fra MO til AD foregår efter en algoritme hvor der itereres hen over
 alle AD brugere. Hver enkelt bruger slås op i MO via feltet `AD_WRITE_UUID` og

--- a/integrations/ad_integration/README.rst
+++ b/integrations/ad_integration/README.rst
@@ -237,8 +237,60 @@ MO til AD
 +++++++++
 
 Synkronisering fra MO til AD foregår efter en algoritme hvor der itereres hen over
-alle AD brugere. Hver enkelt bruger slås op i MO via feltet `AD_WRITE_UUID` og
-informatione fra MO synkroniseres til AD.
+alle AD brugere. Hver enkelt bruger slås op i MO via feltet angivet i nøglen
+`integrations.ad.write.uuid_field` og informatione fra MO synkroniseres
+til AD i henhold til den lokale feltmapning. AD-integrationen stiller et antal
+værdier til rådighed, som det er muligt at synkronisere til felter i AD, flere
+felter formentlig dukke op efterhånden som integrationen udvikles.
+
+ * `employment_number`: Lønsystemets ansættelsesnummer for medarbejderns primære
+   engagement.
+ * `end_date`: Slutdato for længste ansættelse i MO, hvis en ansættelse ikke har
+   nogen kendt slutdato, angives 9999-12-31
+ * `uuid`: Brugerens uuid i MO
+ * `title`: Stillingsbetegnelse for brugerens primære engagement.
+ * `unit`: Navn på enheden for brugerens primære engagement.
+ * `unit_uuid`: UUID på enheden for brugerens primære engagement.
+ * `unit_user_key`: Brugervendt nøgle for enheden for brugerens primære engagement,
+   dette vil typisk være lønssystemets kortnavn for enheden.
+ * `unit_public_email`: Email på brugerens primære enhed med synligheen `offentlig`
+ * `unit_secure_email`: Email på brugerens primære enhed med synligheen `hemmelig`.
+   Hvis enheden kun har email adresser uden angivet synlighed, vil den blive agivet
+   her.
+ * `unit_postal_code`: Postnummer for brugerens primære enhed.
+ * `unit_city`: By for brugerens primære enhed.
+ * `unit_streetname`: Gadenavn for brugerens primære enhed.
+ * `location`: Fuld organisatorisk sti til brugerens primære enhed.
+ * `forvaltning`: Forvaltingen som brugerens primære engagement hører under.
+ * `manager_name`: Navn på leder for brugerens primære engagement.
+ * `manager_sam`: SamAccountName for leder for brugerens primære engagement.
+ * `manager_mail`: Email på lederen for brugerens primære engagement.
+
+Felterne `forvaltning` og `location` synkroniseres altid til felterne angivet i
+nøglerner `integrations.ad.write.forvaltning_type` og
+`integrations.ad.write.org_unit_field`, og skal derfor ikke angives specificeres
+yderligere i feltmapningen.
+
+Desuden synkroniseres  altid AD felterne:
+ * `Displayname` Synkroniseres til medarbejderens fulde navn
+ * `GivenName`: Synkroniseres til medarbejderens fornavn
+ * `SurName`: Synkroniseres til medarbejderens efternavn
+ * `EmployeeNumber`: Synkroniseres til `employment_number`
+
+Yderligere synkronisering fortages i henhold til en lokal feltmaping, som eksempelvis
+kan se ud som dette:
+
+.. code-block:: json
+
+   "integrations.ad_writer.mo_to_ad_fields": {
+	"unit_postal_code": "postalCode",
+	"unit_city": "l",
+	"unit_user_key": "department",
+	"unit_streetname": "streetAddress",
+	"unit_public_email": "extensionAttribute3",
+	"title": "Title",
+	"unit": "extensionAttribute2"
+   }
 
 
 Afvikling af PoerShell templates

--- a/integrations/ad_integration/README.rst
+++ b/integrations/ad_integration/README.rst
@@ -207,9 +207,9 @@ tilknyttet IT-system i MO. Et eksempel på en feltmapning angives herunder:
     }
 
 For adresser angives en synlighed, som kan antage værdien `PUBLIC`, `INTERNAL`,
-`SECRET` eller `null` som angiver henholdsvis at synligheden i MO sættes til
-henholdsvis offentlig, intern, hemmelig, eller ikke angivet. UUID'er er på
-de tilhørende adresseklasser i MO som AD felterne skal mappes til.
+`SECRET` eller `null` som angiver at synligheden i MO sættes til henholdsvis
+offentlig, intern, hemmelig, eller ikke angivet. UUID'er er på de tilhørende
+adresseklasser i MO som AD felterne skal mappes til.
 
 Hvis der for en given bruger er felter i feltmapningen som ikke findes i AD, vil
 disse felter bliver sprunget over, men de øvrige felter vil stadig blive
@@ -218,8 +218,8 @@ sykroniseret.
 Selve synkroniseringen foregår ved at programmet først udtrækker samtlige
 medarbejdere fra MO, der itereres hen over denne liste, og information fra AD'et
 slås op med cpr-nummer som nøgle. Hvis brugeren findes i AD, udlæses alle parametre
-angivet i ``AD_PROPERTIES`` og de af dem som figurerer i feltmapningen synkroniseres
-til MO.
+angivet i `integrations.ad.properties` og de af dem som figurerer i feltmapningen
+synkroniseres til MO.
 
 Integrationen vil som udgangspunkt ikke synkronisere fra et eventuelt skole AD, med
 mindre nøglen `integrations.ad.skip_school_ad_to_mo` sættes til `false`.
@@ -240,14 +240,14 @@ Synkronisering fra MO til AD foregår efter en algoritme hvor der itereres hen o
 alle AD brugere. Hver enkelt bruger slås op i MO via feltet angivet i nøglen
 `integrations.ad.write.uuid_field` og informatione fra MO synkroniseres
 til AD i henhold til den lokale feltmapning. AD-integrationen stiller et antal
-værdier til rådighed, som det er muligt at synkronisere til felter i AD, flere
-felter formentlig dukke op efterhånden som integrationen udvikles.
+værdier til rådighed, som det er muligt at synkronisere til felter i AD. Flere
+lan tilføjes efterhånden som integrationen udvikles.
 
- * `employment_number`: Lønsystemets ansættelsesnummer for medarbejderns primære
+ * `employment_number`: Lønsystemets ansættelsesnummer for medarbejderens primære
    engagement.
  * `end_date`: Slutdato for længste ansættelse i MO, hvis en ansættelse ikke har
-   nogen kendt slutdato, angives 9999-12-31
- * `uuid`: Brugerens uuid i MO
+   nogen kendt slutdato, angives 9999-12-31.
+ * `uuid`: Brugerens UUID i MO.
  * `title`: Stillingsbetegnelse for brugerens primære engagement.
  * `unit`: Navn på enheden for brugerens primære engagement.
  * `unit_uuid`: UUID på enheden for brugerens primære engagement.
@@ -268,8 +268,8 @@ felter formentlig dukke op efterhånden som integrationen udvikles.
 
 Felterne `forvaltning` og `location` synkroniseres altid til felterne angivet i
 nøglerner `integrations.ad.write.forvaltning_type` og
-`integrations.ad.write.org_unit_field`, og skal derfor ikke angives specificeres
-yderligere i feltmapningen.
+`integrations.ad.write.org_unit_field`, og skal derfor ikke specificeres yderligere
+i feltmapningen.
 
 Desuden synkroniseres  altid AD felterne:
  * `Displayname` Synkroniseres til medarbejderens fulde navn

--- a/integrations/ad_integration/ad_sync.py
+++ b/integrations/ad_integration/ad_sync.py
@@ -1,5 +1,4 @@
 import json
-import time
 import pathlib
 import logging
 import requests
@@ -203,13 +202,10 @@ class AdMoSync(object):
         """
 
         # First, check for AD account:
-        t = time.time()
-
         if self.mo_ad_users:
             username = self.mo_ad_users.get(uuid, '')
         else:
             username = self.helper.get_e_username(uuid, 'Active Directory')
-        print('Tid for username read: {}'.format(time.time() - t))
         # If username is blank, we have found a user that needs to be assiged to an
         # IT-system.
         if username is '':
@@ -225,9 +221,7 @@ class AdMoSync(object):
             logger.debug('Response: {}'.format(response.text))
             response.raise_for_status()
 
-        t = time.time()
         fields_to_edit = self._find_existing_ad_address_types(uuid)
-        print('Tid for at finde adresser: {}'.format(time.time() - t))
 
         # Assume no existing adresses, we fix that later
         for field, klasse in self.mapping['user_addresses'].items():

--- a/integrations/ad_integration/ad_sync.py
+++ b/integrations/ad_integration/ad_sync.py
@@ -45,7 +45,7 @@ class AdMoSync(object):
         lora_speedup = self.settings.get(
             'integrations.ad.ad_mo_sync_direct_lora_speedup', False)
         if lora_speedup:
-            self.mo_ad_users = self._cahce_it_systems()
+            self.mo_ad_users = self._cache_it_systems()
         else:
             self.mo_ad_users = {}
 
@@ -70,7 +70,7 @@ class AdMoSync(object):
         self.ad_reader.cache_all()
         logger.info('Done with AD caching')
 
-    def _cahce_it_systems(self):
+    def _cache_it_systems(self):
         logger.info('Cache all it-systems')
         mo_ad_users = {}
         # Get LoRa url from settings
@@ -101,7 +101,7 @@ class AdMoSync(object):
             if it_system == self.mapping['it_systems']['samAccountName']:
                 mo_ad_users[user_uuid] = user_key
 
-        logger.info('Done Cacheing all it-systems')
+        logger.info('Done caching all it-systems')
         return mo_ad_users
 
     def _read_mo_classes(self):

--- a/integrations/ad_integration/ad_sync.py
+++ b/integrations/ad_integration/ad_sync.py
@@ -54,8 +54,10 @@ class AdMoSync(object):
             if not found:
                 raise Exception('Error in visibility class configuration')
 
-        # ad_sync currently does not support school domain.
-        self.ad_reader = ad_reader.ADParameterReader(skip_school=True)
+        skip_school = self.settings.get('integrations.ad.skip_school_ad_to_mo', True)
+        logger.info('Skip school domain: {}'.format(skip_school))
+        self.ad_reader = ad_reader.ADParameterReader(skip_school=skip_school)
+
         self.ad_reader.cache_all()
         logger.info('Done with AD caching')
 


### PR DESCRIPTION
Dette PR åbner for at tillade synkronisering fra skole AD til MO, tilbyder at efter-oprette AD som it-system på brugere som ikke var i AD ved oprettelsen af brugen selv.

Desuden opdatering af dokumentationen af begge synkroniseringsmekanismer.