### PR TITLE
Feature/34265 prefixed settings in python

### DIFF
--- a/tools/prefixed_settings.py
+++ b/tools/prefixed_settings.py
@@ -1,4 +1,5 @@
-#copyright (c) 2017-2018, Magenta ApS
+#
+# Copyright (c) 2017-2018, Magenta ApS
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -13,26 +14,27 @@ import pathlib
 
 def extract_prefixed_envvars(settings, prefix):
     if not prefix.endswith("."):
-        prefix +="."
-    environment=[]
-    prefixlen=len(prefix)
-    for k,v in settings.items():
+        prefix += "."
+    environment = []
+    prefixlen = len(prefix)
+    for k, v in settings.items():
         if (
             k.startswith(prefix) and k.count(".") == prefix.count(".")
         ):
-            if isinstance(v,str):
-                environment.append("export %s=\"%s\"" %(k[prefixlen:],v))
-            elif isinstance(v,bool):
-                environment.append("export %s=%s" %(k[prefixlen:],str(v).lower()))
-            elif isinstance(v,float):
-                environment.append("export %s=%g" %(k[prefixlen:],v))
-            elif isinstance(v,int):
-                environment.append("export %s=%d" %(k[prefixlen:],v))
+            if isinstance(v, str):
+                environment.append("export %s=\"%s\"" % (k[prefixlen:], v))
+            elif isinstance(v, bool):
+                environment.append("export %s=%s" % (k[prefixlen:], str(v).lower()))
+            elif isinstance(v, float):
+                environment.append("export %s=%g" % (k[prefixlen:], v))
+            elif isinstance(v, int):
+                environment.append("export %s=%d" % (k[prefixlen:], v))
     return environment
+
 
 if __name__ == '__main__':
     customer_settings_path = pathlib.Path(os.environ["CUSTOMER_SETTINGS"])
     prefix = os.environ["SETTING_PREFIX"]
     settings = json.loads(customer_settings_path.read_text())
     environment = extract_prefixed_envvars(settings, prefix)
-    print ("\n".join(environment))
+    print("\n".join(environment))

--- a/tools/prefixed_settings.py
+++ b/tools/prefixed_settings.py
@@ -1,0 +1,32 @@
+#copyright (c) 2017-2018, Magenta ApS
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# replace possibly sick jq-script - whoich I accuse of making big swap-files
+
+import os
+import json
+import pathlib
+
+
+def extract_prefixed_envvars(settings, prefix):
+    if not prefix.endswith("."):
+        prefix +="."
+    environment=[]
+    prefixlen=len(prefix)
+    for k,v in settings.items():
+        if (
+            k.startswith(prefix) and isinstance(v, str) 
+            and k.count(".") == prefix.count(".")
+        ):
+            environment.append("export %s=\"%s\"" %(k[prefixlen:],v))
+    return environment
+
+if __name__ == '__main__':
+    customer_settings_path = pathlib.Path(os.environ["CUSTOMER_SETTINGS"])
+    prefix = os.environ["SETTING_PREFIX"]
+    settings = json.loads(customer_settings_path.read_text())
+    environment = extract_prefixed_envvars(settings, prefix)
+    print ("\n".join(environment))

--- a/tools/prefixed_settings.py
+++ b/tools/prefixed_settings.py
@@ -18,10 +18,16 @@ def extract_prefixed_envvars(settings, prefix):
     prefixlen=len(prefix)
     for k,v in settings.items():
         if (
-            k.startswith(prefix) and isinstance(v, str) 
-            and k.count(".") == prefix.count(".")
+            k.startswith(prefix) and k.count(".") == prefix.count(".")
         ):
-            environment.append("export %s=\"%s\"" %(k[prefixlen:],v))
+            if isinstance(v,str):
+                environment.append("export %s=\"%s\"" %(k[prefixlen:],v))
+            elif isinstance(v,bool):
+                environment.append("export %s=%s" %(k[prefixlen:],str(v).lower()))
+            elif isinstance(v,float):
+                environment.append("export %s=%g" %(k[prefixlen:],v))
+            elif isinstance(v,int):
+                environment.append("export %s=%d" %(k[prefixlen:],v))
     return environment
 
 if __name__ == '__main__':

--- a/tools/prefixed_settings.sh
+++ b/tools/prefixed_settings.sh
@@ -16,12 +16,4 @@
 #
 export SETTING_PREFIX=${SETTING_PREFIX:=crontab}
 export CUSTOMER_SETTINGS=${CUSTOMER_SETTINGS:=/opt/settings/customer-settings.json}
-. <(
-    set +x
-    jq -r 'to_entries|map("\(.key)=\(.value|tostring)")[]' ${CUSTOMER_SETTINGS} \
-    | sed -e 's/^'${SETTING_PREFIX}'\.//' \
-    | while IFS="=" read key val
-    do  # only keys with exactly this prefix - no dots
-        [ "${key}" == "${key/\./X}" ] && echo export ${key}=\"$val\"
-    done
-)
+. <(venv/bin/python tools/prefixed_settings.py)

--- a/tools/tests/test_prefixed_settings.py
+++ b/tools/tests/test_prefixed_settings.py
@@ -1,8 +1,9 @@
 import unittest
-
 from tools import prefixed_settings
+
+
 class Tests(unittest.TestCase):
-    
+
     def test_prefixed_settings_with_dot(self):
         self.assertEqual(sorted(prefixed_settings.extract_prefixed_envvars(
             {
@@ -11,43 +12,43 @@ class Tests(unittest.TestCase):
                 "manuel.CYKEL": "Min",
                 "manuella": "Theirs"
             }, "manuel.")), [
-                'export BIL="Din"', 
+                'export BIL="Din"',
                 'export CYKEL="Min"'
             ])
 
     def test_prefixed_settings_no_dot(self):
         self.assertEqual(sorted(prefixed_settings.extract_prefixed_envvars(
             {
-                "manuel.børnehave.CYKEL":"Børnehavens",
+                "manuel.børnehave.CYKEL": "Børnehavens",
                 "manuel.CYKEL": "Min",
                 "manuel.BIL": "Din",
                 "manuella": "Theirs"
             }, "manuel")), [
-                'export BIL="Din"', 
+                'export BIL="Din"',
                 'export CYKEL="Min"',
             ])
 
     def test_prefixed_settings_int(self):
         self.assertEqual(sorted(prefixed_settings.extract_prefixed_envvars(
-            { "manuel.torsk": 0, }, "manuel")),
+            {"manuel.torsk": 0}, "manuel")),
             ['export torsk=0']
         )
 
     def test_prefixed_settings_float(self):
         self.assertEqual(sorted(prefixed_settings.extract_prefixed_envvars(
-            { "manuel.torsk": 0.1, }, "manuel")),
+            {"manuel.torsk": 0.1}, "manuel")),
             ['export torsk=0.1']
         )
 
     def test_prefixed_settings_boolean(self):
         self.assertEqual(sorted(prefixed_settings.extract_prefixed_envvars(
-            { "manuel.torsk": False, }, "manuel")),
+            {"manuel.torsk": False}, "manuel")),
             ['export torsk=false']
         )
- 
+
     def test_prefixed_settings_more_dots(self):
         self.assertEqual(sorted(prefixed_settings.extract_prefixed_envvars(
             {
-                "manuel.børnehave.CYKEL":"Børnehavens",
-                "manuel.BIL":"Din",
+                "manuel.børnehave.CYKEL": "Børnehavens",
+                "manuel.BIL": "Din",
             }, "manuel.børnehave")), ['export CYKEL="Børnehavens"'])

--- a/tools/tests/test_prefixed_settings.py
+++ b/tools/tests/test_prefixed_settings.py
@@ -6,26 +6,48 @@ class Tests(unittest.TestCase):
     def test_prefixed_settings_with_dot(self):
         self.assertEqual(sorted(prefixed_settings.extract_prefixed_envvars(
             {
-                "manuel.børnehave.CYKEL":"Børnehavens",
-                "manuel.BIL":"Din",
-                "manuel.CYKEL":"Min",
-                "manuella":"Theirs"
-            }, "manuel.")), ['export BIL="Din"', 'export CYKEL="Min"'])
+                "manuel.børnehave.CYKEL": "Børnehavens",
+                "manuel.BIL": "Din",
+                "manuel.CYKEL": "Min",
+                "manuella": "Theirs"
+            }, "manuel.")), [
+                'export BIL="Din"', 
+                'export CYKEL="Min"'
+            ])
 
     def test_prefixed_settings_no_dot(self):
         self.assertEqual(sorted(prefixed_settings.extract_prefixed_envvars(
             {
                 "manuel.børnehave.CYKEL":"Børnehavens",
-                "manuel.CYKEL":"Min",
-                "manuel.BIL":"Din",
-                "manuella":"Theirs"
-            }, "manuel")), ['export BIL="Din"', 'export CYKEL="Min"'])
+                "manuel.CYKEL": "Min",
+                "manuel.BIL": "Din",
+                "manuella": "Theirs"
+            }, "manuel")), [
+                'export BIL="Din"', 
+                'export CYKEL="Min"',
+            ])
 
+    def test_prefixed_settings_int(self):
+        self.assertEqual(sorted(prefixed_settings.extract_prefixed_envvars(
+            { "manuel.torsk": 0, }, "manuel")),
+            ['export torsk=0']
+        )
+
+    def test_prefixed_settings_float(self):
+        self.assertEqual(sorted(prefixed_settings.extract_prefixed_envvars(
+            { "manuel.torsk": 0.1, }, "manuel")),
+            ['export torsk=0.1']
+        )
+
+    def test_prefixed_settings_boolean(self):
+        self.assertEqual(sorted(prefixed_settings.extract_prefixed_envvars(
+            { "manuel.torsk": False, }, "manuel")),
+            ['export torsk=false']
+        )
+ 
     def test_prefixed_settings_more_dots(self):
         self.assertEqual(sorted(prefixed_settings.extract_prefixed_envvars(
             {
                 "manuel.børnehave.CYKEL":"Børnehavens",
-                "manuel.CYKEL":"Min",
                 "manuel.BIL":"Din",
-                "manuella":"Theirs"
             }, "manuel.børnehave")), ['export CYKEL="Børnehavens"'])

--- a/tools/tests/test_prefixed_settings.py
+++ b/tools/tests/test_prefixed_settings.py
@@ -1,0 +1,31 @@
+import unittest
+
+from tools import prefixed_settings
+class Tests(unittest.TestCase):
+    
+    def test_prefixed_settings_with_dot(self):
+        self.assertEqual(sorted(prefixed_settings.extract_prefixed_envvars(
+            {
+                "manuel.børnehave.CYKEL":"Børnehavens",
+                "manuel.BIL":"Din",
+                "manuel.CYKEL":"Min",
+                "manuella":"Theirs"
+            }, "manuel.")), ['export BIL="Din"', 'export CYKEL="Min"'])
+
+    def test_prefixed_settings_no_dot(self):
+        self.assertEqual(sorted(prefixed_settings.extract_prefixed_envvars(
+            {
+                "manuel.børnehave.CYKEL":"Børnehavens",
+                "manuel.CYKEL":"Min",
+                "manuel.BIL":"Din",
+                "manuella":"Theirs"
+            }, "manuel")), ['export BIL="Din"', 'export CYKEL="Min"'])
+
+    def test_prefixed_settings_more_dots(self):
+        self.assertEqual(sorted(prefixed_settings.extract_prefixed_envvars(
+            {
+                "manuel.børnehave.CYKEL":"Børnehavens",
+                "manuel.CYKEL":"Min",
+                "manuel.BIL":"Din",
+                "manuella":"Theirs"
+            }, "manuel.børnehave")), ['export CYKEL="Børnehavens"'])


### PR DESCRIPTION
ændring af læsning af environment til shwell-script - ikke fordi jheg ved at det er det, der er i vejen, men fordi jeg ikke har andre bud end det her med jq og så muligheden af en vim i en screen.

Vi rydder denne af vejen, så har vi vel kun den anden tilbage
