### PR TITLE
quotes a must when testing for empty, set -e not working (exit 1)

### DIFF
--- a/tools/job-runner.sh
+++ b/tools/job-runner.sh
@@ -193,19 +193,19 @@ exports_viborg_emus(){
 exports_viborg_eksterne(){
     set -e
     echo "running viborgs eksterne"
-    ${VENV}/bin/python3 exporters/viborg_eksterne/viborg_eksterne.py
+    ${VENV}/bin/python3 exporters/viborg_eksterne/viborg_eksterne.py || exit 1
     $(
         SETTING_PREFIX="mora.folder" source ${DIPEXAR}/tools/prefixed_settings.sh
         SETTING_PREFIX="integrations.ad" source ${DIPEXAR}/tools/prefixed_settings.sh
         SETTING_PREFIX="exports_viborg_eksterne" source ${DIPEXAR}/tools/prefixed_settings.sh
-        system_user=${system_user%%@*}
-        [ -z ${query_export} ] && exit 1
-        [ -z ${system_user} ] && exit 1
-        [ -z ${password} ] && exit 1
-        [ -z ${destination_smb_share} ] && exit 1
-        [ -z ${destination_directory} ] && exit 1
-        [ -z ${outfile_basename} ] && exit 1
-        [ -z ${workgroup} ] && exit 1
+        system_user="${system_user%%@*}"
+        [ -z "${query_export}" ] && exit 1
+        [ -z "${system_user}" ] && exit 1
+        [ -z "${password}" ] && exit 1
+        [ -z "${destination_smb_share}" ] && exit 1
+        [ -z "${destination_directory}" ] && exit 1
+        [ -z "${outfile_basename}" ] && exit 1
+        [ -z "${workgroup}" ] && exit 1
 
         cd ${query_export}
         smbclient -U "${system_user}%${password}"  \


### PR DESCRIPTION
Quotes var glemt, set -e virkede vist ikke er og er derfor erstattet af en || exit 1