### PR TITLE
Feature/34311 engagement mapping

### DIFF
--- a/integrations/SD_Lon/README.rst
+++ b/integrations/SD_Lon/README.rst
@@ -34,7 +34,7 @@ Desuden kan disse ikke-påkrævede felter angives:
    `EmploymentName` i dette felt.
  * ``integrations.SD_Lon.skip_employment_types``: En liste over værdier af
    `JobPositionIdentifier` som ikke skal importeres. Hvis et engagement har
-   en type fra listen, vil engagementet bliver ignorere og ikke importeret i MO.
+   en type fra listen, vil engagementet bliver ignoreret og ikke importeret i MO.
    Den tilhørende bruger vil dog blive oprettet, men vil optræde uden engagementer
    (med mindre personen har andre engagementer i kommunen).
 

--- a/integrations/SD_Lon/README.rst
+++ b/integrations/SD_Lon/README.rst
@@ -225,7 +225,7 @@ Hjælpeværktøjer
 Udover de direkte værktøjer til import og løbende opdateringer, findes et antal
 hjælpeværktøjer:
 
- * `calculate_primary.py`: Et værktøj som er i stand til at gennemløbe alle
+ * ``calculate_primary.py``: Et værktøj som er i stand til at gennemløbe alle
    ansættelser i MO og afgøre om der for alle medarbejdere til alle tider
    findes et primærengagement. Værktøjet er også i stand til at reparere en
    (eller alle) ansættelser hvor dette ikke skulle være tilfældet. Dette modul
@@ -240,7 +240,7 @@ hjælpeværktøjer:
    med ansættelsestyper og stillingsbetegnelser som er knyttet til SDs
    ``JobPositionIdentifier``. Efter den initielle import vil klassens navn modsvare
    talværdien i SD, og dette værktøj kan efterfølgende anvendes til at enten at
-   synkronisere teksten til  den aktuelle værdi i SD eller til en valgfri tekst.
+   synkronisere teksten til den aktuelle værdi i SD eller til en valgfri tekst.
 
  * ``fix_departments.py``: En implementering af logikken beskrevet under afsnitet
    `Håndtering af enheder`_. Udover anvendelsen i den løbende integrationen,
@@ -251,7 +251,7 @@ hjælpeværktøjer:
    vil det opdatere alle enhedens ansættelser, så engagementerne flyttes til
    de korrekte NY-niveauer (som kan være ændret, hvis afdelingen er flyttet).
 
- * `sd_fix_organisation.py`: Tidligere forsøg på at håndtere opdateringer af
+ * ``sd_fix_organisation.py``: Tidligere forsøg på at håndtere opdateringer af
    enheder. Scriptet findes nu kun som basis for evenutelle senere forsøg på
    at lave et fuldt historisk import af enhedstræet.
 

--- a/integrations/SD_Lon/README.rst
+++ b/integrations/SD_Lon/README.rst
@@ -225,6 +225,10 @@ Hjælpeværktøjer
 Udover de direkte værktøjer til import og løbende opdateringer, findes et antal
 hjælpeværktøjer:
 
+ * ``test_sd_connectivity``: Et lille værktøj som tester at den lokale
+   ``settings.json`` indeholder de nødvendige nøgler. Desuden tester programmet
+   for en række potentielle fejl, eksempevis om felterne har gyldige værdier
+   og om det er muligt at kotakte SD Løn med de angivne brugeroplysinger.
  * ``calculate_primary.py``: Et værktøj som er i stand til at gennemløbe alle
    ansættelser i MO og afgøre om der for alle medarbejdere til alle tider
    findes et primærengagement. Værktøjet er også i stand til at reparere en

--- a/integrations/SD_Lon/README.rst
+++ b/integrations/SD_Lon/README.rst
@@ -26,9 +26,17 @@ af SD Løn. De påkrævede felter er:
  * ``integrations.SD_Lon.monthly_hourly_divide``: Skilleværdi for måneds/timelønnede.
  * ``integrations.SD_Lon.job_function``: Feltet kan have en af to vædier:
    `EmploymentName` eller `JobPositionIdentifier`, se yderligere nedenfor.
+
+Desuden kan disse ikke-påkrævede felter angives:
+
  * ``integrations.SD_Lon.employment_field``: Angiver et af MOs ekstrafelter på
    engagementer, hvis feltet angives vil integrationen skrive værdien af
    `EmploymentName` i dette felt.
+ * ``integrations.SD_Lon.skip_employment_types``: En liste over værdier af
+   `JobPositionIdentifier` som ikke skal importeres. Hvis et engagement har
+   en type fra listen, vil engagementet bliver ignorere og ikke importeret i MO.
+   Den tilhørende bruger vil dog blive oprettet, men vil optræde uden engagementer
+   (med mindre personen har andre engagementer i kommunen).
 
 Hvis ``integrations.SD_Lon.job_function`` har værdien `EmploymentName` vil
 ansættelsers stillingsbetegnelser bliver taget fra SDs felt af samme navn, som

--- a/integrations/SD_Lon/README.rst
+++ b/integrations/SD_Lon/README.rst
@@ -24,6 +24,18 @@ af SD Løn. De påkrævede felter er:
  * ``integrations.SD_Lon.import.too_deep``: Liste over SD niveauer som anses som
    afdelingsniveau.
  * ``integrations.SD_Lon.monthly_hourly_divide``: Skilleværdi for måneds/timelønnede.
+ * ``integrations.SD_Lon.job_function``: Feltet kan have en af to vædier:
+   `EmploymentName` eller `JobPositionIdentifier`, se yderligere nedenfor.
+ * ``integrations.SD_Lon.employment_field``: Angiver et af MOs ekstrafelter på
+   engagementer, hvis feltet angives vil integrationen skrive værdien af
+   `EmploymentName` i dette felt.
+
+Hvis `integrations.SD_Lon.job_function`` har værdien `EmploymentName` vil
+ansættelsers stilingsbetegnelser bliver taget fra SDs felt af samme navn, som
+er et fritekstfelt, integrationen vil oprette en klasse for alle forekommende
+stillingsbetegnelser.
+Benyttes i stedet værdien `JobPositionIdentifier` vil stillingsbetegelsen blive
+taget fra dette felt i SD, som er et klassicieret felt.
 
 Desuden er det nødvendigt at angive adressen på MO og LoRa i variablerne:
  * ``mox.base``
@@ -224,10 +236,10 @@ hjælpeværktøjer:
    primære engagementer for en enkelt bruger eller for alle brugere.
 
  * ``sync_job_id.py``: Dette værktøj kan opdatere den tekst som vises i forbindelse
-   med ansættelsestyper som er knyttet til SDs ``JobPositionIdentifier``. Efter
-   den initielle import vil klassens navn modsvare talværdien i SD, og dette
-   værktøj kan efterfølgende anvendes til at enten at synkronisere teksten til
-   den aktuelle værdi i SD eller til en valgfri tekst.
+   med ansættelsestyper og stillingsbetegnelser som er knyttet til SDs
+   ``JobPositionIdentifier``. Efter den initielle import vil klassens navn modsvare
+   talværdien i SD, og dette værktøj kan efterfølgende anvendes til at enten at
+   synkronisere teksten til  den aktuelle værdi i SD eller til en valgfri tekst.
 
  * ``fix_departments.py``: En implementering af logikken beskrevet under afsnitet
    `Håndtering af enheder`_. Udover anvendelsen i den løbende integrationen,

--- a/integrations/SD_Lon/README.rst
+++ b/integrations/SD_Lon/README.rst
@@ -233,10 +233,19 @@ Hjælpeværktøjer
 Udover de direkte værktøjer til import og løbende opdateringer, findes et antal
 hjælpeværktøjer:
 
- * ``test_sd_connectivity``: Et lille værktøj som tester at den lokale
+ * ``test_sd_connectivity.py``: Et lille værktøj som tester at den lokale
    ``settings.json`` indeholder de nødvendige nøgler. Desuden tester programmet
    for en række potentielle fejl, eksempevis om felterne har gyldige værdier
    og om det er muligt at kotakte SD Løn med de angivne brugeroplysinger.
+
+ * ``test_mo_against_sd.py``: Et værktøj som tester udvalgte personers engagementer
+   mod SD løn of checker at MO og SD er løn har samme opfattelse af om personens
+   engagementer er aktive eller ej. Værktøjet kan anvendes på et enkelt person
+   eller på alle personer som har ansættelse i en bestemt enhed (alle engagementer
+   for disse personer vil blive tjekket også dem i andre enheder). Værktøjet
+   anvender opslag til SDs API'er og kan derfor kun anvendes i begrænset omfang, og
+   af samme årsag er der ikke implementeret mulighed for at tjekke alle ansatte.
+
  * ``calculate_primary.py``: Et værktøj som er i stand til at gennemløbe alle
    ansættelser i MO og afgøre om der for alle medarbejdere til alle tider
    findes et primærengagement. Værktøjet er også i stand til at reparere en

--- a/integrations/SD_Lon/README.rst
+++ b/integrations/SD_Lon/README.rst
@@ -13,7 +13,7 @@ Opsætning
 ==========
 
 For at kunne afvikle integrationen, kræves loginoplysninger til SD-Løn, som angives
-via``settings.json``, desuden anvendes en række felter som angiver den lokale anvendelse
+via ``settings.json``, desuden anvendes en række felter som angiver den lokale anvendelse
 af SD Løn. De påkrævede felter er:
 
  * ``integrations.SD_Lon.institution_identifier``: Institution Identifer i SD.
@@ -30,14 +30,15 @@ af SD Løn. De påkrævede felter er:
    engagementer, hvis feltet angives vil integrationen skrive værdien af
    `EmploymentName` i dette felt.
 
-Hvis `integrations.SD_Lon.job_function`` har værdien `EmploymentName` vil
-ansættelsers stilingsbetegnelser bliver taget fra SDs felt af samme navn, som
-er et fritekstfelt, integrationen vil oprette en klasse for alle forekommende
+Hvis ``integrations.SD_Lon.job_function`` har værdien `EmploymentName` vil
+ansættelsers stillingsbetegnelser bliver taget fra SDs felt af samme navn, som
+er et fritekstfelt. Integrationen vil oprette en klasse for alle forekommende
 stillingsbetegnelser.
 Benyttes i stedet værdien `JobPositionIdentifier` vil stillingsbetegelsen blive
 taget fra dette felt i SD, som er et klassicieret felt.
 
 Desuden er det nødvendigt at angive adressen på MO og LoRa i variablerne:
+
  * ``mox.base``
  * ``mora.base``
 

--- a/integrations/SD_Lon/exceptions.py
+++ b/integrations/SD_Lon/exceptions.py
@@ -1,2 +1,5 @@
+class JobfunctionSettingsIsWrongException(Exception):
+    pass
+
 class NoCurrentValdityException(Exception):
     pass

--- a/integrations/SD_Lon/fix_departments.py
+++ b/integrations/SD_Lon/fix_departments.py
@@ -125,7 +125,7 @@ class FixDepartments(object):
     def fix_department_at_single_date(self, unit_uuid, validity_date):
         """
         Synchronize the state of a MO unit to the current state in SD.
-        The updated validity of the MO unit will extend from 1900-01-01 to infinity
+        The updated validity of the MO unit will extend from 1930-01-01 to infinity
         and any existing validities will be overwritten.
         :param unit_uuid: uuid of the unit to be updated.
         :param validity_date: The validity date to read the departent info from SD.
@@ -162,7 +162,7 @@ class FixDepartments(object):
 
         # SD has a challenge with the internal validity-consistency, extend
         # validity indefinitely
-        from_date = '1900-01-01'
+        from_date = '1930-01-01'
         msg = 'Unit parent at {} is {}'
         print(msg.format(from_date, parent))
         logger.info(msg.format(from_date, parent))
@@ -441,7 +441,7 @@ class FixDepartments(object):
         Run through all units up to the top of the tree and synchroize the state of
         MO to the state of SD. This includes reanming of MO units, moving MO units
         and creating units that currently does not exist in MO. The updated validity
-        of the MO units will extend from 1900-01-01 to infinity and any existing
+        of the MO units will extend from 1930-01-01 to infinity and any existing
         validities will be overwritten.
         :param leaf_uuid: The starting point of the fix, this does not stictly need
         to be a leaf node.

--- a/integrations/SD_Lon/fix_departments_currently_unsed_code.py
+++ b/integrations/SD_Lon/fix_departments_currently_unsed_code.py
@@ -127,7 +127,7 @@ def fix_specific_department(self, shortname):
         # SD has a challenge with the internal validity-consistency, extend first
         # validity indefinitely
         if first_iteration:
-            from_date = '1900-01-01'
+            from_date = '1930-01-01'
             first_iteration = False
         else:
             from_date = validity_date.strftime('%Y-%m-%d')

--- a/integrations/SD_Lon/sd_changed_at.py
+++ b/integrations/SD_Lon/sd_changed_at.py
@@ -35,7 +35,7 @@ for name in logging.root.manager.loggerDict:
 
 cfg_file = pathlib.Path.cwd() / 'settings' / 'settings.json'
 if not cfg_file.is_file():
-    raise Exception('No setting file')
+    raise Exception('No settings file')
 # TODO: This must be clean up, settings should be loaded by __init__
 # and no references should be needed in global scope.
 SETTINGS = json.loads(cfg_file.read_text())
@@ -542,11 +542,11 @@ class ChangeAtSD(object):
             engagement_type = self.engagement_types.get(job_position)
             logger.info('Non-nummeric id. Job pos id: {}'.format(job_position))
 
-        ext_field = self.settings.get('integrations.SD_Lon.employment_field')
-        if ext_field is not None:
-            extention = {ext_field: emp_name}
+        extension_field = self.settings.get('integrations.SD_Lon.employment_field')
+        if extension_field is not None:
+            extension = {extension_field: emp_name}
         else:
-            extention = {}
+            extension = {}
 
         payload = sd_payloads.create_engagement(
             org_unit=org_unit,
@@ -557,7 +557,7 @@ class ChangeAtSD(object):
             user_key=user_key,
             engagement_info=engagement_info,
             validity=validity,
-            **extention
+            **extension
         )
 
         response = self.helper._mo_post('details/create', payload)

--- a/integrations/SD_Lon/sd_changed_at.py
+++ b/integrations/SD_Lon/sd_changed_at.py
@@ -598,6 +598,14 @@ class ChangeAtSD(object):
         response = self.helper._mo_post('details/terminate', payload)
         logger.debug('Terminate response: {}'.format(response.text))
         mora_assert(response)
+
+        self.mo_engagement = self.helper.read_user_engagement(
+            self.mo_person['uuid'],
+            read_all=True,
+            only_primary=True,
+            use_cache=False
+        )
+
         return True
 
     def _edit_engagement_department(self, engagement, mo_eng):
@@ -684,7 +692,10 @@ class ChangeAtSD(object):
 
             # Should this have an end comparison and cut=True?
             # Most likely not, but be aware of the option.
-            validity = self._validity(worktime_info, mo_eng['validity']['to'])
+            print('MO eng: {}'.format(mo_eng))
+            validity = self._validity(worktime_info, mo_eng['validity']['to'],
+                                      cut=True)
+            print('Edit worktime validity: {}'.format(validity))
             # As far as we know, this can only happen for work time
             if validity is None:
                 continue

--- a/integrations/SD_Lon/sd_changed_at.py
+++ b/integrations/SD_Lon/sd_changed_at.py
@@ -690,13 +690,8 @@ class ChangeAtSD(object):
         for worktime_info in engagement_info['working_time']:
             logger.info('Change working time of engagement {}'.format(job_id))
 
-            # Should this have an end comparison and cut=True?
-            # Most likely not, but be aware of the option.
-            print('MO eng: {}'.format(mo_eng))
             validity = self._validity(worktime_info, mo_eng['validity']['to'],
                                       cut=True)
-            print('Edit worktime validity: {}'.format(validity))
-            # As far as we know, this can only happen for work time
             if validity is None:
                 continue
 

--- a/integrations/SD_Lon/sd_importer.py
+++ b/integrations/SD_Lon/sd_importer.py
@@ -97,7 +97,6 @@ class SdImport(object):
             for row in self.manager_rows:
                 resp = row.get('ansvar')
                 self._add_klasse(resp, resp, 'responsibility')
-                print(resp)
 
         self._add_klasse('leder_type', 'Leder', 'manager_type')
 
@@ -233,7 +232,8 @@ class SdImport(object):
             if self._check_subtree(department, sub_tree):
                 import_unit = True
 
-            parent_uuid = department['DepartmentReference']['DepartmentUUIDIdentifier']
+            parent_uuid = department[
+                'DepartmentReference']['DepartmentUUIDIdentifier']
             if self.org_id_prefix:
                 parent_uuid = self._generate_uuid(parent_uuid, self.org_id_prefix)
         else:
@@ -497,11 +497,8 @@ class SdImport(object):
                     continue
 
                 employment_id = calc_employment_id(employment)
-                occupation_rate = float(employment['WorkingTime']
-                                        ['OccupationRate'])
-
-                # if occupation_rate == 0:
-                # continue
+                occupation_rate = float(
+                    employment['WorkingTime']['OccupationRate'])
 
                 if occupation_rate == max_rate:
                     if employment_id['value'] < min_id:
@@ -513,30 +510,29 @@ class SdImport(object):
             exactly_one_primary = False
             for employment in employments:
                 status = employment['EmploymentStatus']['EmploymentStatusCode']
-                # Find a valid job_function name, this might be overwritten from
-                # AD, if an AD value is available for this employment
-                job_id = int(employment['Profession']['JobPositionIdentifier'])
-                try:
-                    job_func = employment['Profession']['EmploymentName']
-                except KeyError:
-                    job_func = employment['Profession']['JobPositionIdentifier']
 
-                occupation_rate = float(employment['WorkingTime']
-                                        ['OccupationRate'])
+                # Job_position_id: Klassificeret liste over stillingstyper.
+                # job_name: Fritiksfelt med stillingsbetegnelser.
+                job_position_id = employment['Profession']['JobPositionIdentifier']
+                job_name = employment['Profession'].get(
+                    'EmploymentName', job_position_id)
+
+                occupation_rate = float(
+                    employment['WorkingTime']['OccupationRate'])
 
                 employment_id = calc_employment_id(employment)
 
-                employment['Profession']['JobPositionIdentifier']
                 split = self.settings['integrations.SD_Lon.monthly_hourly_divide']
                 if employment_id['value'] < split:
                     engagement_type_ref = 'månedsløn'
                 elif (split - 1) < employment_id['value'] < 999999:
                     engagement_type_ref = 'timeløn'
                 else:  # This happens if EmploymentID is not a number
-                    s_job_id = str(job_id)
-                    self._add_klasse(s_job_id, s_job_id, 'engagement_type')
-                    engagement_type_ref = s_job_id
-                    logger.info('Non-nummeric id. Job pos id: {}'.format(s_job_id))
+                    engagement_type_ref = 'engagement_type' + job_position_id
+                    self._add_klasse(
+                        engagement_type_ref, job_position_id, 'engagement_type')
+                    logger.info(
+                        'Non-nummeric id. Job pos id: {}'.format(job_position_id))
 
                 if occupation_rate == max_rate and employment_id['value'] == min_id:
                     assert(exactly_one_primary is False)
@@ -548,9 +544,16 @@ class SdImport(object):
                 if status == '0':  # If status 0, uncondtionally override
                     primary_type_ref = 'status0'
 
-                job_func_ref = self._add_klasse(job_func,
-                                                job_func,
-                                                'engagement_job_function')
+                job_function_type = self.settings['integrations.SD_Lon.job_function']
+                if job_function_type == 'EmploymentName':
+                    job_func_ref = self._add_klasse(
+                        job_name, job_name, 'engagement_job_function')
+                elif job_function_type == 'JobPositionIdentifier':
+                    job_func_ref = self._add_klasse(
+                        job_position_id, job_position_id, 'engagement_job_function')
+                else:
+                    raise Exception('integrations.SD_Lon.job_function is wrong')
+
                 emp_dep = employment['EmploymentDepartment']
                 unit = emp_dep['DepartmentUUIDIdentifier']
 
@@ -604,6 +607,9 @@ class SdImport(object):
                     #                                 self.org_name)
 
                     # We explicitly do not want identical uuids for engagements
+                    ext_field = self.settings['integrations.SD_Lon.employment_field']
+                    extention = {ext_field: job_name}
+
                     self.importer.add_engagement(
                         employee=cpr,
                         # uuid=engagement_uuid,
@@ -614,7 +620,8 @@ class SdImport(object):
                         primary_ref=primary_type_ref,
                         engagement_type_ref=engagement_type_ref,
                         date_from=date_from,
-                        date_to=date_to
+                        date_to=date_to,
+                        **extention
                     )
                     # Remove this to remove any sign of the employee from the
                     # lowest levels of the org
@@ -641,11 +648,11 @@ class SdImport(object):
                 if not self.manager_rows:
                     # These job functions will normally (but necessarily)
                     #  correlate to a manager position
-                    if job_id in [1040, 1035, 1030]:
+                    if int(job_position_id) in [1040, 1035, 1030]:
                         self.importer.add_manager(
                             employee=cpr,
                             organisation_unit=unit,
-                            manager_level_ref=job_id,
+                            manager_level_ref=job_position_id,
                             address_uuid=None,  # Manager address is not used
                             manager_type_ref='leder_type',
                             responsibility_list=['Lederansvar'],
@@ -659,8 +666,8 @@ class SdImport(object):
                         if 'uuid' not in row:
                             logger.warning('NO UNIT: {}'.format(row['afdeling']))
                             continue
-                        if job_id in [1040, 1035, 1030]:
-                            manager_level = job_id
+                        if int(job_position_id) in [1040, 1035, 1030]:
+                            manager_level = int(job_position_id)
                         else:
                             manager_level = 1040
 

--- a/integrations/SD_Lon/sd_importer.py
+++ b/integrations/SD_Lon/sd_importer.py
@@ -431,7 +431,7 @@ class SdImport(object):
                 name='Forældreløse enheder',
                 user_key='OrphanUnits',
                 type_ref='Orphan',
-                date_from='1900-01-01',
+                date_from='1930-01-01',
                 date_to=None,
                 parent_ref=None
             )
@@ -693,7 +693,7 @@ class SdImport(object):
                             manager_level_ref=manager_level,
                             manager_type_ref='leder_type',
                             responsibility_list=[row['ansvar']],
-                            date_from='1900-01-01',
+                            date_from='1930-01-01',
                             date_to=None
                         )
 

--- a/integrations/SD_Lon/sd_importer.py
+++ b/integrations/SD_Lon/sd_importer.py
@@ -606,9 +606,12 @@ class SdImport(object):
                     #                                 self.org_id_prefix,
                     #                                 self.org_name)
 
-                    # We explicitly do not want identical uuids for engagements
-                    ext_field = self.settings['integrations.SD_Lon.employment_field']
-                    extention = {ext_field: job_name}
+                    ext_field = self.settings.get(
+                        'integrations.SD_Lon.employment_field')
+                    if ext_field is not None:
+                        extention = {ext_field: job_name}
+                    else:
+                        extention = {}
 
                     self.importer.add_engagement(
                         employee=cpr,

--- a/integrations/SD_Lon/sd_payloads.py
+++ b/integrations/SD_Lon/sd_payloads.py
@@ -90,7 +90,7 @@ def create_leave(mo_eng, mo_person, leave_uuid, job_id, validity):
 
 
 def create_engagement(org_unit, mo_person, job_function, engagement_type,
-                      primary, user_key, engagement_info, validity):
+                      primary, user_key, engagement_info, validity, **extensions):
     try:
         working_time = float(engagement_info['working_time'][0]['OccupationRate'])
     except IndexError:
@@ -106,6 +106,7 @@ def create_engagement(org_unit, mo_person, job_function, engagement_type,
         'fraction': int(working_time * 1000000),
         'validity': validity
     }
+    payload.update(extensions)
     return payload
 
 
@@ -160,7 +161,6 @@ def profession(profession, org, job_function_facet):
         'to': 'infinity'
     }
 
-    # "integrationsdata":  # TODO: Check this
     properties = {
         'brugervendtnoegle': profession,
         'titel':  profession,

--- a/integrations/SD_Lon/sd_payloads.py
+++ b/integrations/SD_Lon/sd_payloads.py
@@ -135,7 +135,7 @@ def connect_it_system_to_user(username, it_system, person_uuid):
     return payload
 
 
-def edit_engagement_type(titel):
+def edit_klasse_title(titel):
     payload = {
         "attributter": {
             "klasseegenskaber": [

--- a/integrations/SD_Lon/sd_payloads.py
+++ b/integrations/SD_Lon/sd_payloads.py
@@ -129,7 +129,7 @@ def connect_it_system_to_user(username, it_system, person_uuid):
         'itsystem': {'uuid': it_system},
         'person': {'uuid': person_uuid},
         'validity': {
-            'from': '1900-01-01',
+            'from': '1930-01-01',
             'to': None
         }
     }
@@ -143,7 +143,7 @@ def edit_klasse_title(titel):
                 {
                     'titel': titel,
                     'virkning': {
-                        'from': '1900-01-01',
+                        'from': '1930-01-01',
                         'to': 'infinity',
                         'aktoerref': 'ddc99abd-c1b0-48c2-aef7-74fea841adae',
                         'aktoertypekode': 'Bruger'
@@ -157,7 +157,7 @@ def edit_klasse_title(titel):
 
 def profession(profession, org, job_function_facet):
     validity = {
-        'from': '1900-01-01',
+        'from': '1930-01-01',
         'to': 'infinity'
     }
 

--- a/integrations/SD_Lon/sync_job_id.py
+++ b/integrations/SD_Lon/sync_job_id.py
@@ -1,5 +1,7 @@
 import json
+import atexit
 import pathlib
+import logging
 import argparse
 import requests
 import sd_payloads
@@ -7,38 +9,94 @@ from os2mo_helpers.mora_helpers import MoraHelper
 from integrations.SD_Lon.sd_common import sd_lookup
 from integrations.SD_Lon.sd_common import mora_assert
 
-# TODO: We now need to sync both engagement types and job_functions!
+LOG_LEVEL = logging.DEBUG
+LOG_FILE = 'sync_job_id.log'
+
+logger = logging.getLogger('sdSyncJobId')
+
+for name in logging.root.manager.loggerDict:
+    if name in ('sdSyncJobId', 'sdCommon', 'mora-helper'):
+        logging.getLogger(name).setLevel(LOG_LEVEL)
+    else:
+        logging.getLogger(name).setLevel(logging.ERROR)
+
+logging.basicConfig(
+    format='%(levelname)s %(asctime)s %(name)s %(message)s',
+    level=LOG_LEVEL,
+    filename=LOG_FILE
+)
+
 
 class JobIdSync(object):
     def __init__(self):
+        logger.info('Start sync')
+        atexit.register(self.at_exit)
         cfg_file = pathlib.Path.cwd() / 'settings' / 'settings.json'
         if not cfg_file.is_file():
             raise Exception('No setting file')
         self.settings = json.loads(cfg_file.read_text())
 
-        helper = MoraHelper(hostname=self.settings['mora.base'],
-                            use_cache=False)
+        helper = MoraHelper(hostname=self.settings['mora.base'], use_cache=False)
         self.engagement_types = helper.read_classes_in_facet('engagement_type')
 
+        if self.settings[
+                'integrations.SD_Lon.job_function'] == 'JobPositionIdentifier':
+            logger.info('Read settings. Update job_functions and engagment types')
+            self.job_function_types = helper.read_classes_in_facet(
+                'engagement_job_function')
+            self.update_job_functions = True
+        else:
+            logger.info('Read settings. Do not update job_functions')
+            self.update_job_functions = False
+
+    def at_exit(self):
+        logger.info('*Sync ended*')
+
     def _find_engagement_type(self, job_pos_id):
+        """
+        Find a Klasse in facet engagement_type corresponding to job_pos_id in LoRa.
+        The search is performed both by direct search as well as with prefixed
+        string engagement_type (which is used in the municipalities who also use
+        the job_pos_ids as job_functions).
+        """
+        logger.info('Search MO for engagment_type {}'.format(job_pos_id))
+        found_type = None
+        user_keys = [str(job_pos_id), 'engagement_type' + str(job_pos_id)]
+        for engagement_type in self.engagement_types[0]:
+            if engagement_type['user_key'] in user_keys:
+                found_type = engagement_type
+        logger.info('Found {}'.format(found_type))
+        return found_type
+
+    def _find_job_function_type(self, job_pos_id):
         """
         Find the Klasse corresponding to job_pos_id in LoRa.
         """
         found_type = None
-        for engagement_type in self.engagement_types[0]:
-            if engagement_type['user_key'] == str(job_pos_id):
-                found_type = engagement_type
+        if not self.update_job_functions:
+            logger.info('Job functons not enabled in settings')
+            return found_type
+
+        logger.info('Search MO for job_function_type {}'.format(job_pos_id))
+        # Currently we do not use a prefix anywhere, list has only one element
+        user_keys = [str(job_pos_id)]
+        for job_function_type in self.job_function_types[0]:
+            if job_function_type['user_key'] in user_keys:
+                found_type = job_function_type
+        logger.info('Found {}'.format(found_type))
         return found_type
 
-    def _edit_engagement_type(self, uuid, title):
+    def _edit_klasse_title(self, uuid, title):
         """
         Change the title of an existing LoRa engagement type.
         """
-        payload = sd_payloads.edit_engagement_type(title)
+        logger.info('Edit {} to {}'.format(uuid, title))
+        payload = sd_payloads.edit_klasse_title(title)
         response = requests.patch(
             url=self.settings['mox.base'] + '/klassifikation/klasse/' + uuid,
             json=payload
         )
+        logger.info('Lora response: {}'.format(response.status_code))
         mora_assert(response)
         return response
 
@@ -46,6 +104,7 @@ class JobIdSync(object):
         """
         Return the textual value of a Job Position Identifier fro SD.
         """
+        logger.info('Search SD for {}'.format(job_pos_id))
         params = {
             'JobPositionIdentifier': job_pos_id,
         }
@@ -54,6 +113,7 @@ class JobIdSync(object):
             job_pos = job_pos_response['Profession']['JobPositionName']
         else:
             job_pos = None
+        logger.info('Found {}'.format(job_pos_id))
         return job_pos
 
     def sync_to_sd(self, job_pos_id):
@@ -61,26 +121,62 @@ class JobIdSync(object):
         Sync the titel of LoRa engagement type to the value current
         registred at SD.
         """
-        job_pos = self.get_job_pos_id_from_sd(job_pos_id)
-        if job_pos is None:
-            return 'Job position not found i SD'
+        logger.info('Sync {} to value found in SD'.format(job_pos_id))
+        return_status = [None, None]
+        sd_job_pos_text = self.get_job_pos_id_from_sd(job_pos_id)
+        if sd_job_pos_text is None:
+            logger.warning('Job position {} not found i SD'.format(job_pos_id))
+            return return_status
 
-        mo_type = self._find_engagement_type(job_pos_id)
-        if mo_type is None:
-            return 'Job position not found i MO'
+        mo_eng_type = self._find_engagement_type(job_pos_id)
+        if mo_eng_type is None:
+            return_status[0] = False
+            logger.info('Engagement type {} not found i MO'.format(job_pos_id))
+        else:
+            return_status[0] = True
+            self._edit_klasse_title(mo_eng_type['uuid'], sd_job_pos_text)
+            logger.info('Updated engagement type: {}'.format(job_pos_id))
 
-        self._edit_engagement_type(mo_type['uuid'], job_pos)
-        return 'Job position updated'
+        # Only run this part, if we are actually using
+        if self.update_job_functions:
+            mo_job_function_type = self._find_job_function_type(job_pos_id)
+            if mo_job_function_type is None:
+                return_status[1] = False
+                logger.info('job function type {} not found i MO'.format(job_pos_id))
+            else:
+                self._edit_klasse_title(mo_job_function_type['uuid'],
+                                        sd_job_pos_text)
+                return_status[1] = True
+                logger.info('Updated job function type type: {}'.format(job_pos_id))
 
-    def sync_manually(self, job_pos_id, titel):
+        logger.info('Return status: {}'.format(return_status))
+        return return_status
+
+    def sync_manually(self, job_pos_id, title):
         """
         Manually update the titel of an engagement type.
         """
+        logger.info('Sync {} to {}'.format(job_pos_id, title))
+        return_status = [None, None]
+
         mo_type = self._find_engagement_type(job_pos_id)
         if mo_type is None:
-            return 'Job position not found i MO'
+            return_status[0] = False
+            logger.info('Job position not found i MO')
+        else:
+            return_status[0] = True
+            self._edit_klasse_titel(mo_type['uuid'], title)
 
-        self._edit_engagement_type(mo_type['uuid'], titel)
+        if self.update_job_functions:
+            mo_job_function_type = self._find_job_function_type(job_pos_id)
+            if mo_job_function_type is None:
+                return_status[1] = False
+                logger.info('job function type {} not found i MO'.format(job_pos_id))
+            else:
+                return_status[1] = True
+                self._edit_klasse_title(mo_job_function_type['uuid'], title)
+                logger.info('Updated job function type type: {}'.format(job_pos_id))
+
         return 'Job position updated'
 
     def _cli(self):

--- a/integrations/SD_Lon/sync_job_id.py
+++ b/integrations/SD_Lon/sync_job_id.py
@@ -7,6 +7,7 @@ from os2mo_helpers.mora_helpers import MoraHelper
 from integrations.SD_Lon.sd_common import sd_lookup
 from integrations.SD_Lon.sd_common import mora_assert
 
+# TODO: We now need to sync both engagement types and job_functions!
 
 class JobIdSync(object):
     def __init__(self):

--- a/integrations/SD_Lon/sync_job_id.py
+++ b/integrations/SD_Lon/sync_job_id.py
@@ -109,10 +109,10 @@ class JobIdSync(object):
             'JobPositionIdentifier': job_pos_id,
         }
         job_pos_response = sd_lookup('GetProfession20080201', params)
-        if 'Profession' in job_pos_response:
+        job_pos = None
+        while 'Profession' in job_pos_response:
             job_pos = job_pos_response['Profession']['JobPositionName']
-        else:
-            job_pos = None
+            job_pos_response = job_pos_response['Profession']
         logger.info('Found {}'.format(job_pos_id))
         return job_pos
 

--- a/integrations/SD_Lon/sync_job_id.py
+++ b/integrations/SD_Lon/sync_job_id.py
@@ -75,7 +75,7 @@ class JobIdSync(object):
         found_type = None
         if not self.update_job_functions:
             logger.info('Job functons not enabled in settings')
-            return found_type
+            return None
 
         logger.info('Search MO for job_function_type {}'.format(job_pos_id))
         # Currently we do not use a prefix anywhere, list has only one element
@@ -102,7 +102,7 @@ class JobIdSync(object):
 
     def _get_job_pos_id_from_sd(self, job_pos_id):
         """
-        Return the textual value of a Job Position Identifier fro SD.
+        Return the textual value of a Job Position Identifier from SD.
         """
         logger.info('Search SD for {}'.format(job_pos_id))
         params = {

--- a/integrations/SD_Lon/sync_job_id.py
+++ b/integrations/SD_Lon/sync_job_id.py
@@ -158,12 +158,14 @@ class JobIdSync(object):
             user_key = eng_type['user_key']
             if user_key.startswith('engagement_type'):
                 user_key = user_key[15:]
-            print('Sync from SD: {}'.format(user_key))  # self.sync_from_sd(user_key)
+            print('Sync from SD: {}'.format(user_key))
+            self.sync_from_sd(user_key)
 
         if self.update_job_functions:
             for job_function in self.job_function_types[0]:
                 user_key = job_function['user_key']
-                print('Sync from SD: {}'.format(user_key))  # self.sync_from_sd(user_key)
+                print('Sync from SD: {}'.format(user_key))
+                self.sync_from_sd(user_key)
         logger.info('Full sync completed')
 
     def sync_manually(self, job_pos_id, title):

--- a/integrations/SD_Lon/test_mo_against_sd.py
+++ b/integrations/SD_Lon/test_mo_against_sd.py
@@ -1,0 +1,90 @@
+import json
+import pathlib
+
+from datetime import datetime
+
+from os2mo_helpers.mora_helpers import MoraHelper
+from integrations.SD_Lon.sd_common import sd_lookup
+
+
+class TestMoAgainsSd(object):
+    def __init__(self):
+        cfg_file = pathlib.Path.cwd() / 'settings' / 'settings.json'
+        if not cfg_file.is_file():
+            raise Exception('No setting file')
+        self.settings = json.loads(cfg_file.read_text())
+        self.date = datetime.now()
+
+        self.helper = MoraHelper(hostname=self.settings['mora.base'],
+                                 use_cache=False)
+
+    def _compare_employments(self, employment, mo_eng):
+        # job_position_id = employment['Profession']['JobPositionIdentifier']
+        status = employment['EmploymentStatus']['EmploymentStatusCode']
+        # occupation_rate = float(employment['WorkingTime']['OccupationRate'])
+
+        # TODO, we should also consider to check for actual date_values.
+        # This would need a loop that finds the entire validity of the engagement
+        if status in ['1', '3']:
+            # Check that MO agrees that the engagement is active
+            if mo_eng['validity']['from'] < self.date < mo_eng['validity']['to']:
+                print('Engagement is correctly current')
+            else:
+                print('Engagement validity is not correct in MO!')
+                exit(1)
+
+        elif status in ['7', '8', '9']:
+            # employment_end_date = employment['EmploymentStatus']['ActivationDate']
+            if mo_eng['validity']['to'] < self.date:
+                print('Engagement is correctly in the past')
+            else:
+                print('Engagement validity is not correct in MO!')
+            pass
+        else:
+            print('Unhandled status, fix this program')
+            exit(1)
+
+    def check_user(self, mo_uuid):
+        mo_user = self.helper.read_user(user_uuid=mo_uuid)
+        mo_engagements = self.helper.read_user_engagement(
+            user=mo_uuid, read_all=True, only_primary=True)
+        for eng in mo_engagements:
+            if eng['validity']['to'] is None:
+                eng['validity']['to'] = '9999-12-31'
+            eng['validity']['from'] = datetime.strptime(
+                eng['validity']['from'], '%Y-%m-%d')
+            eng['validity']['to'] = datetime.strptime(
+                eng['validity']['to'], '%Y-%m-%d')
+
+        # Notice, this will not get future engagements
+        params = {
+            'PersonCivilRegistrationIdentifier': mo_user['cpr_no'],
+            'StatusActiveIndicator': 'true',
+            'StatusPassiveIndicator': 'true',
+            'DepartmentIndicator': 'true',
+            'EmploymentStatusIndicator': 'true',
+            'ProfessionIndicator': 'true',
+            'WorkingTimeIndicator': 'true',
+            'UUIDIndicator': 'true',
+            'SalaryAgreementIndicator': 'false',
+            'SalaryCodeGroupIndicator': 'false',
+            'EffectiveDate': self.date.strftime('%d.%m.%Y')
+        }
+        sd_employments_response = sd_lookup('GetEmployment20111201', params)
+        employments = sd_employments_response['Person']['Employment']
+        if not isinstance(employments, list):
+            employments = [employments]
+
+        for employment in employments:
+            employment_id = employment['EmploymentIdentifier']
+            found_mo_eng = False
+            for mo_eng in mo_engagements:
+                if mo_eng['user_key'] == employment_id:
+                    found_mo_eng = True
+                    self._compare_employments(employment, mo_eng)
+            if not found_mo_eng:
+                print('Unable to find {} in MO!'.format(employment_id))
+                exit(1)
+
+if __name__ == '__main__':
+    tester = TestMoAgainsSd()

--- a/integrations/SD_Lon/test_sd_connectivity.py
+++ b/integrations/SD_Lon/test_sd_connectivity.py
@@ -1,0 +1,127 @@
+import json
+import pathlib
+from uuid import UUID
+
+
+class TestSdConnectivity(object):
+    def __init__(self):
+        cfg_file = pathlib.Path.cwd() / 'settings' / 'settings.json'
+        if not cfg_file.is_file():
+            raise Exception('No setting file')
+        self.settings = json.loads(cfg_file.read_text())
+
+    def _check_existens_of_keys(self):
+        print('Check for tilstedeværlse af konfigurationsøgler')
+        needed_keys = [
+            'integrations.SD_Lon.sd_user',
+            'integrations.SD_Lon.sd_password',
+            'integrations.SD_Lon.institution_identifier',
+            'integrations.SD_Lon.import.too_deep',
+            'integrations.SD_Lon.global_from_date',
+            'integrations.SD_Lon.monthly_hourly_divide',
+            'integrations.SD_Lon.job_function',
+            'integrations.SD_Lon.import.run_db'
+        ]
+
+        missing_keys = []
+        for key in needed_keys:
+            if self.settings.get(key) is None:
+                missing_keys.append(key)
+        if missing_keys:
+            print(' * Manglende nøgler: {}'.format(missing_keys))
+            exit(1)
+        else:
+            print(' * Alle nødvendige nøgler fundet')
+
+        nice_to_have_keys = [
+            'integrations.SD_Lon.employment_field',
+            'integrations.SD_Lon.import.manager_file'
+        ]
+        wanted_keys = []
+        for key in nice_to_have_keys:
+            if self.settings.get(key) is None:
+                wanted_keys.append(key)
+        if wanted_keys:
+            print('Disse ikke-kritiske nøgler mangler: {}'.format(missing_keys))
+        else:
+            print(' * Alle ikke-kritiske nøgler fundet')
+        print()
+
+    def _check_legal_values(self):
+        print('Tjekker at settings-værdier er gyldige:')
+
+        legal_job_functions = ['EmploymentName', 'JobPositionIdentifier']
+        legal_extensions = [
+            'extension_1', 'extension_2', 'extension_3', 'extension_4',
+            'extension_5', 'extension_6', 'extension_7', 'extension_8',
+            'extension_9', 'extension_10'
+        ]
+
+        job_function = self.settings['integrations.SD_Lon.job_function']
+        if job_function in legal_job_functions:
+            print(' * Job function nøgle er korrekt')
+        else:
+            print(' * Job function nøgle skal være{}'.format(legal_job_functions))
+            exit(1)
+
+        employment_field = self.settings.get('integrations.SD_Lon.employment_field')
+        if employment_field is not None and employment_field in legal_extensions:
+            print(' * Felt til stillingsbetegnelse er korrekt')
+        else:
+            print(' * Felt til stillingsbetegnelse skal være {}'.format(
+                legal_job_functions))
+            exit(1)
+
+        manager_file = self.settings.get('integrations.SD_Lon.import.manager_file')
+        if manager_file is not None:
+            manager_path = pathlib.Path(manager_file)
+            if manager_path.is_file():
+                print(' * Specificeret lederfil er fundet')
+            else:
+                print(' * Specificeret lederfil er ikke fundet')
+                exit(1)
+            if manager_path.suffix == '.csv':
+                print(' * Specificeret lederfil er korrekt en csv-fil')
+            else:
+                print(' * Specificeret lederfil skal være en csv-fil')
+                exit(1)
+
+        # TODO:
+        # Tjek at run_db stien er korrekt.
+        print()
+
+    def _check_contact_to_sd(self):
+        print('Tjekker at vi har kontakt til SD:')
+        from integrations.SD_Lon.sd_common import sd_lookup
+
+        inst_id = self.settings['integrations.SD_Lon.institution_identifier']
+        params = {
+            'UUIDIndicator': 'true',
+            'InstitutionIdentifier': inst_id
+        }
+        try:
+            institution_info = sd_lookup(
+                'GetInstitution20111201', params, use_cache=False)
+        except Exception as e:
+            print('Fejl i kontak til SD Løn: {}'.format(e))
+            exit(1)
+
+        try:
+            institution = institution_info['Region']['Institution']
+            institution_uuid = institution['InstitutionUUIDIdentifier']
+            UUID(institution_uuid, version=4)
+            print(' * Korrekt kontakt til SD Løn')
+        except Exception as e:
+            msg = ' * Fik forbindelse, men modtog ikke-korrekt svar fra SD: {}, {}'
+            print(msg.format(institution_uuid, e))
+            exit(1)
+
+    def sd_check(self):
+        self._check_existens_of_keys()
+        self._check_legal_values()
+        self._check_contact_to_sd()
+
+
+if __name__ == '__main__':
+    tsc = TestSdConnectivity()
+    tsc.sd_check()

--- a/integrations/SD_Lon/test_sd_connectivity.py
+++ b/integrations/SD_Lon/test_sd_connectivity.py
@@ -105,10 +105,6 @@ class TestSdConnectivity(object):
                     exit(1)
             print(' * skip_employment_types er korrekt')
 
-        # TODO:
-        # Tjek at run_db stien er korrekt.
-        print()
-
     def _check_contact_to_sd(self):
         print('Tjekker at vi har kontakt til SD:')
         from integrations.SD_Lon.sd_common import sd_lookup

--- a/integrations/SD_Lon/test_sd_connectivity.py
+++ b/integrations/SD_Lon/test_sd_connectivity.py
@@ -8,7 +8,11 @@ class TestSdConnectivity(object):
         cfg_file = pathlib.Path.cwd() / 'settings' / 'settings.json'
         if not cfg_file.is_file():
             raise Exception('No setting file')
-        self.settings = json.loads(cfg_file.read_text())
+        try:
+            self.settings = json.loads(cfg_file.read_text())
+        except json.decoder.JSONDecodeError as e:
+            print('Syntax error in settings file: {}'.format(e))
+            exit(1)
 
     def _check_existens_of_keys(self):
         print('Check for tilstedeværlse af konfigurationsøgler')
@@ -35,7 +39,8 @@ class TestSdConnectivity(object):
 
         nice_to_have_keys = [
             'integrations.SD_Lon.employment_field',
-            'integrations.SD_Lon.import.manager_file'
+            'integrations.SD_Lon.import.manager_file',
+            'integrations.SD_Lon.skip_employment_types'
         ]
         wanted_keys = []
         for key in nice_to_have_keys:
@@ -85,6 +90,20 @@ class TestSdConnectivity(object):
             else:
                 print(' * Specificeret lederfil skal være en csv-fil')
                 exit(1)
+
+        skip_job_functions = self.settings.get(
+            'integrations.SD_Lon.skip_employment_types')
+        if skip_job_functions is not None:
+            if not isinstance(skip_job_functions, list):
+                print('skip_employment_types skal være en liste')
+                exit(1)
+            for job_function in skip_job_functions:
+                try:
+                    int(job_function)
+                except ValueError:
+                    print('All elementer i skip_employment_types skal være tal')
+                    exit(1)
+            print(' * skip_employment_types er korrekt')
 
         # TODO:
         # Tjek at run_db stien er korrekt.

--- a/integrations/ad_integration/ad_sync.py
+++ b/integrations/ad_integration/ad_sync.py
@@ -41,6 +41,18 @@ class AdMoSync(object):
                                  use_cache=False)
         self.org = self.helper.read_organisation()
 
+        if 'it_systems' in self.mapping:
+            mo_it_systems = self.helper.read_it_systems()
+
+            for it_system, it_system_uuid in self.mapping['it_systems'].items():
+                found = False
+                for mo_it_system in mo_it_systems:
+                    if mo_it_system['uuid'] == it_system_uuid:
+                        found = True
+                if not found:
+                    msg = '{} with uuid {}, not found in MO'
+                    raise Exception(msg.format(it_system, it_system_uuid))
+
         # Possibly get IT-system directly from LoRa for better performance.
         lora_speedup = self.settings.get(
             'integrations.ad.ad_mo_sync_direct_lora_speedup', False)

--- a/os2mo_data_import/os2mo_data_import/mora_data_types.py
+++ b/os2mo_data_import/os2mo_data_import/mora_data_types.py
@@ -216,7 +216,7 @@ class EngagementType(MoType):
 
     def __init__(self, org_unit_ref, job_function_ref, engagement_type_ref,
                  date_from, date_to=None, uuid=None, user_key=None, fraction=None,
-                 primary_ref=None):
+                 primary_ref=None, **kwargs):
         super().__init__()
 
         self.type_id = "engagement"
@@ -245,6 +245,8 @@ class EngagementType(MoType):
 
         self.date_from = date_from
         self.date_to = date_to
+
+        self.extentions = kwargs
 
     def build(self):
         """
@@ -316,6 +318,9 @@ class EngagementType(MoType):
             self.payload['user_key'] = self.user_key
         self.payload['fraction'] = self.fraction
 
+        # Todo: Consider a check for the value of the keys.
+        self.payload.update(self.extentions)
+        
         return self._build_payload()
 
 

--- a/settings/kommune-andeby.json
+++ b/settings/kommune-andeby.json
@@ -41,7 +41,6 @@
     "integrations.SD_Lon.sd_user": "",
     "integrations.SD_Lon.sd_password": "",
     "integrations.SD_Lon.institution_identifier": "",
-    "integrations.SD_Lon.unknown_parent_container": "uuid-for-parent-container",
     "integrations.SD_Lon.import.too_deep": [
         "liste", 
         "af", 
@@ -49,6 +48,9 @@
     ] ,
     "integrations.SD_Lon.global_from_date": "YYYY-mm-dd",
     "integrations.SD_Lon.import.run_db": "/path/to/CRON/run_db.sqlite",
+    "#integrations.SD_Lon.job_function": 'EmploymentName',
+    "integrations.SD_Lon.job_function": 'JobPositionIdentifier',
+    "integrations.SD_Lon.employment_field": 'extension_1',
     "#integrations.SD_Lon.import.manager_file": "/path/to/manager_file",
     "#integrations.SD_Lon.sd_mox.AMQP_HOST": "msg-amqp.silkeborgdata.dk",
     "#integrations.SD_Lon.sd_mox.AMQP_PORT": 5672,


### PR DESCRIPTION
Ny feature til SD import: Mulighed for at vælge mellem at stillingsbetegnelser skal tages fra SDs fritekstfelt, eller den klassificerede JobPositionIdentifier. Der er oprettet nye nøgler i settings.json til konfiguration af dette.

Dokumentationen er opdateret til at reflektere de nye muligheder.

Værktøjet sync-job-id er opdateret så det nu kan synkronisere til både engagementstyper og de nye typer stillingsbetegnelser.

Der er desuden lavet to nye værktøjer for at hjælpe med at holde rede på opsætningen hos de forskellige kunder når importværktøjet udvikler sig:
 - test_sd_connectivity.py: Værktøj analogt til det man kender fra AD integrationens test_connectivity, værktøjet tjekker at de SD specifikke nøgler i settings.json er til stedet og gyldige, og tjekker desuden at de angivne credentials giver adgang til SDs api.

- test_mo_against_sd.py: Kommandolinjeværktøj som giver mulighed for at teste udvalgte personers engagementer mod deres tilstand i SD. Værktøjet tjekker i øjeblikket alene på engagementets aktiv-status (altså, om engagementet er nutidigt eller fortidigt), men kan senere udvikles yderligere.
