### PR TITLE
Ensure the import stops immidiately if an SD lookup fails.

### DIFF
--- a/integrations/SD_Lon/sd_common.py
+++ b/integrations/SD_Lon/sd_common.py
@@ -63,11 +63,13 @@ def sd_lookup(url, params={}, use_cache=True):
             pickle.dump(response, f, pickle.HIGHEST_PROTOCOL)
 
     dict_response = xmltodict.parse(response.text)
+
     if url in dict_response:
         xml_response = dict_response[url]
     else:
-        logger.error('Envelope: {}'.format(dict_response['Envelope']))
-        xml_response = {}
+        msg = 'SD api error, envelope: {}'
+        logger.error(msg.format(dict_response['Envelope']))
+        raise Exception(msg.format(dict_response['Envelope']))
     logger.debug('Done with {}'.format(url))
     return xml_response
 


### PR DESCRIPTION
Sikrer at vi fejler prompte ved kommunikationsfejl så vi kan rette fejlen uden at skulle indlæse gammel backup.