### PR TITLE
35563-discard-job-functions

### DIFF
--- a/exporters/emus/README.rst
+++ b/exporters/emus/README.rst
@@ -45,6 +45,8 @@ Nøglen, ``employee_id``, som overføres er tjenestenr.
 
 Timelønnede medarbejdere er ikke med i udtrækket.
 
+I settings.json vedligeholdes en liste af frasorterede job-funktioner, som også fjernes fra udtrækket
+
 
 Organisatoriske enheder
 -----------------------
@@ -73,17 +75,18 @@ Styring af udtrækket
 
 Programmet er afhængig af følgende indstillinger i ``settings.json``
 
- * ``crontab.MORA_BASE`` styrer hvilken OS2MO, der tilgås 
- * ``crontab.MORA_ROOT_ORG_UNIT_NAME`` angiver roden af det organisatoriske træ, der skal overføres
- * ``crontab.USERID_ITSYSTEM`` angiver hvilket IT-system, man tager brugernavnet fra, default er ``Active Directory``.
- * ``crontab.EMUS_RESPONSIBILITY_CLASS`` angiver den leder-klasse man vil overføre
- * ``crontab.EMUS_FILENAME`` default ``emus_filename.xml`` er det filnavn viborg_xml_emus.py kan skrive til
- * ``crontab.SFTP_USER`` angiver den sftp-user, man forbinder som
- * ``crontab.SFTP_HOST`` er typisk ``sftp.serviceplatformen.dk``, men til test kan en anden anvendes
- * ``crontab.SFTP_KEY_PATH`` angiver den nøgle, man anvender got at forbinde sig til sftp-serveren
- * ``crontab.SFTP_KEY_PASSPHRASE`` angiver password til ovenst. nøgle
- * ``crontab.MUSSKEMA_RECIPIENT`` angiver den bruger, som man skal sende til. Dette giver kun mening med sftp på serviceplatformen
- * ``crontab.QUERY_EXPORT_DIR`` angiver det sted, hvor kopien af rapporten skal lægges - dette skal være det output-dir, som kan nås igennem OS2MO.
+ * ``emus.discard_job_functions`` angiver jobfunktioner, der skal springes over
+ * ``emus.manager_responsibility_class`` angiver den leder-klasse man vil overføre
+ * ``emus.outfile_name`` default ``emus_filename.xml`` er det filnavn viborg_xml_emus.py kan skrive til
+ * ``emus.recipient`` angiver den bruger, som man skal sende til. Dette giver kun mening med sftp på serviceplatformen
+ * ``emus.sftp_host`` er typisk ``sftp.serviceplatformen.dk``, men til test kan en anden anvendes
+ * ``emus.sftp_key_passphrase`` angiver password til ovenst. nøgle
+ * ``emus.sftp_key_path`` angiver den nøgle, man anvender got at forbinde sig til sftp-serveren
+ * ``emus.sftp_user`` angiver den sftp-user, man forbinder som
+ * ``emus.userid_itsystem`` angiver hvilket IT-system, man tager brugernavnet fra, default er ``Active Directory``.
+ * ``mora.admin_top_unit`` angiver roden af det organisatoriske træ, der skal overføres
+ * ``mora.base`` styrer hvilken OS2MO, der tilgås
+ * ``mora.folder.query_export`` angiver det sted, hvor kopien af rapporten skal lægges - dette skal være det output-dir, som kan nås igennem OS2MO.
 
 
 Programmet kan styres af følgende environment-variable:

--- a/exporters/emus/viborg_xml_emus_sftp.py
+++ b/exporters/emus/viborg_xml_emus_sftp.py
@@ -8,19 +8,15 @@ from exporters.emus.viborg_xml_emus import settings, main as generate_file
 
 logger = logging.getLogger("emus-sftp")
 
-logger.info("checking settings")
-try:
-    MORA_BASE = settings["mora.base"]
-    SFTP_USER = settings["emus.sftp_user"]
-    SFTP_HOST = settings["emus.sftp_host"]
-    SFTP_KEY_PATH = settings["emus.sftp_key_path"]
-    SFTP_KEY_PASSPHRASE = settings["emus.sftp_key_passphrase"]
-    MUSSKEMA_RECIPIENT = settings["emus.recipient"]
-    QUERY_EXPORT_DIR = os.environ.get("mora.folder.query_export")
-    EMUS_FILENAME = settings.get("emus.outfile_name", 'emus_filename.xml')
-except Exception as e:
-    logger.error(e)
-    raise KeyError(str(e))
+logger.info("reading settings")
+MORA_BASE = settings["mora.base"]
+SFTP_USER = settings["emus.sftp_user"]
+SFTP_HOST = settings["emus.sftp_host"]
+SFTP_KEY_PATH = settings["emus.sftp_key_path"]
+SFTP_KEY_PASSPHRASE = settings["emus.sftp_key_passphrase"]
+MUSSKEMA_RECIPIENT = settings["emus.recipient"]
+QUERY_EXPORT_DIR = settings["mora.folder.query_export"]
+EMUS_FILENAME = settings.get("emus.outfile_name", 'emus_filename.xml')
 
 
 def main():

--- a/exporters/emus/viborg_xml_emus_sftp.py
+++ b/exporters/emus/viborg_xml_emus_sftp.py
@@ -4,22 +4,23 @@ import datetime
 import logging
 from spsftp import SpSftp
 from os2mo_helpers.mora_helpers import MoraHelper
-from exporters.emus.viborg_xml_emus import main as generate_file, EMUS_FILENAME
+from exporters.emus.viborg_xml_emus import settings, main as generate_file
 
 logger = logging.getLogger("emus-sftp")
 
-logger.info("checking environment")
-MORA_BASE = os.environ.get('MORA_BASE', 'http://localhost:5000')
+logger.info("checking settings")
 try:
-    SFTP_USER = os.environ["SFTP_USER"]
-    SFTP_HOST = os.environ["SFTP_HOST"]
-    SFTP_KEY_PATH = os.environ["SFTP_KEY_PATH"]
-    SFTP_KEY_PASSPHRASE = os.environ["SFTP_KEY_PASSPHRASE"]
-    MUSSKEMA_RECIPIENT = os.environ["MUSSKEMA_RECIPIENT"]
-    QUERY_EXPORT_DIR = os.environ.get("QUERY_EXPORT_DIR")
+    MORA_BASE = settings["mora.base"]
+    SFTP_USER = settings["emus.sftp_user"]
+    SFTP_HOST = settings["emus.sftp_host"]
+    SFTP_KEY_PATH = settings["emus.sftp_key_path"]
+    SFTP_KEY_PASSPHRASE = settings["emus.sftp_key_passphrase"]
+    MUSSKEMA_RECIPIENT = settings["emus.recipient"]
+    QUERY_EXPORT_DIR = os.environ.get("mora.folder.query_export")
+    EMUS_FILENAME = settings.get("emus.outfile_name", 'emus_filename.xml')
 except Exception as e:
     logger.error(e)
-    raise EnvironmentError(str(e))
+    raise KeyError(str(e))
 
 
 def main():

--- a/settings/kommune-andeby.json
+++ b/settings/kommune-andeby.json
@@ -27,6 +27,7 @@
     "crontab.OS2MO_COMPOSE_YML":"/path/to/os2mo/docker-compose.yml",
 
     "mox.base": "http://example.com/mox",
+    "mora.admin_top_unit": "angiver roden af det organisatoriske træ, der skal overføres(emus/os2sync)",
     "mora.base": "http://example.com/mora",
     "mora.folder.query_export":"path-to-where-os2mo-reads-csv-files",
     "municipality.name": "Andeby Kommune",
@@ -34,6 +35,19 @@
     "address.visibility.secret": "uuid-for-secret-address",
     "address.visibility.internal": "uuid-for-internal-address",
     "address.visibility.public": "uuid-for-public-address",
+
+    "emus.discard_job_functions": "angiver jobfunktioner, der skal springes over",
+    "emus.manager_responsibility_class": "angiver den leder-klasse man vil overføre",
+    "emus.outfile_name": "default ``emus_filename.xml`` er det filnavn viborg_xml_emus.py kan skrive til",
+    "emus.recipient":"angiver den bruger, som man skal sende til. Dette giver kun mening med sftp på serviceplatformen",
+    "emus.sftp_host":"er typisk ``sftp.serviceplatformen.dk``, men til test kan en anden anvendes",
+    "emus.sftp_key_passphrase": "angiver password til ovenst. nøgle",
+    "emus.sftp_key_path": "angiver den nøgle, man anvender got at forbinde sig til sftp-serveren",
+    "emus.sftp_user": "angiver den sftp-user, man forbinder som",
+    "emus.userid_itsystem": "angiver hvilket IT-system, man tager brugernavnet fra, default er ``Active Directory",
+
+
+
     "exports_viborg_eksterne.destination_smb_share":"smb-share",
     "exports_viborg_eksterne.destination_directory":"directory-name",
     "exports_viborg_eksterne.workgroup":"Windows-WORKGROUP",


### PR DESCRIPTION
emus-programmet er nu blevet autoriseret til at læse settingsfilen, har fået sine egne nægler, og dermed kan vi rydde lidt op i dem, der ligger under crontab.*

Der er også en enkelt funktionel rettelse - vi kan nu frasortere jobfunktioner. Det er dog ikke testet, så jeg havde egentlig håbet på at få det merget og så få lov af dig til at teste med denne gren på viborg. Vi kan også gøre det med development og så tage de rettelser, der kommer der i en ny gren.

Whatever rocks Your goat, som Lauesen siger.
