### PR TITLE
Feature/35838 import single opus user

### DIFF
--- a/integrations/brønderslev/brønderslev.py
+++ b/integrations/brønderslev/brønderslev.py
@@ -5,6 +5,7 @@ import argparse
 from os2mo_data_import import ImportHelper
 
 from integrations.ad_integration import ad_reader
+from integrations.opus.opus_helpers import update_employee
 from integrations.opus.opus_helpers import start_opus_diff
 from integrations.opus.opus_helpers import start_opus_import
 from integrations.opus.opus_exceptions import RunDBInitException
@@ -13,17 +14,20 @@ parser = argparse.ArgumentParser(description='Brønderslev import')
 group = parser.add_mutually_exclusive_group()
 group.add_argument('--import', action='store_true', help='New import into empty MO')
 group.add_argument('--update', action='store_true', help='Update with next xml file')
+group.add_argument('--update-single-user', nargs=1, metavar='Emmploymentnumber',
+                   help='Update a single user')
+parser.add_argument('--days', nargs=1, type=int, metavar='Days to go back',
+                    help='Number of days in the past to sync single user',
+                    default=[1000])
+
 args = vars(parser.parse_args())
 
-# TODO: Soon we have done this 4 times. Should we make a small settings
-# importer, that will also handle datatype for specicic keys?
 cfg_file = pathlib.Path.cwd() / 'settings' / 'settings.json'
 if not cfg_file.is_file():
     raise Exception('No setting file')
 SETTINGS = json.loads(cfg_file.read_text())
 
 ad_reader = ad_reader.ADParameterReader()
-
 
 if args['update']:
     try:
@@ -45,3 +49,8 @@ if args['import']:
         start_opus_import(importer, ad_reader=ad_reader, force=True)
     except RunDBInitException:
         print('RunDB not initialized')
+
+if args.get('update_single_user'):
+    employment_number = args.get('update_single_user')[0]
+    days = args['days'][0]
+    update_employee(employment_number, days)

--- a/integrations/furesø/furesø.py
+++ b/integrations/furesø/furesø.py
@@ -5,6 +5,7 @@ import argparse
 from os2mo_data_import import ImportHelper
 
 from integrations.ad_integration import ad_reader
+from integrations.opus.opus_helpers import update_employee
 from integrations.opus.opus_helpers import start_opus_diff
 from integrations.opus.opus_helpers import start_opus_import
 from integrations.opus.opus_exceptions import RunDBInitException
@@ -13,6 +14,12 @@ parser = argparse.ArgumentParser(description='Furesø import')
 group = parser.add_mutually_exclusive_group()
 group.add_argument('--import', action='store_true', help='New import into empty MO')
 group.add_argument('--update', action='store_true', help='Update with next xml file')
+group.add_argument('--update-single-user', nargs=1, metavar='Emmploymentnumber',
+                   help='Update a single user')
+parser.add_argument('--days', nargs=1, type=int, metavar='Days to go back',
+                    help='Number of days in the past to sync single user',
+                    default=[1000])
+
 args = vars(parser.parse_args())
 
 cfg_file = pathlib.Path.cwd() / 'settings' / 'settings.json'
@@ -29,7 +36,6 @@ if args['update']:
         print('RunDB not initialized')
 
 if args['import']:
-
     importer = ImportHelper(
         create_defaults=True,
         mox_base=SETTINGS['mox.base'],
@@ -43,3 +49,8 @@ if args['import']:
         start_opus_import(importer, ad_reader=ad_reader, force=True)
     except RunDBInitException:
         print('RunDB not initialized')
+
+if args.get('update_single_user'):
+    employment_number = args.get('update_single_user')[0]
+    days = args['days'][0]
+    update_employee(employment_number, days)

--- a/integrations/opus/README.rst
+++ b/integrations/opus/README.rst
@@ -161,6 +161,20 @@ Opus-data, og vælger at arbejde sig igennem gamle dumps for at importere histor
 daglig brug vil mapningen ikke have nogen betydning, da oprettede brugere her altid
 vil være nye.
 
+Opdatering af enkelte brugere
+=============================
+
+Skulle det af den ene eller den anden grund ske, at en bruger ikke er importeret
+korrekt, er det muligt at efterimportere denne bruger. Funktionen er endnu ret ny
+og det tilrådes derfor altid at tage en backup af databasen før den benyttes.
+Funktionen fungerer ved at hente historiske data fra gamle xml-dumps, og det er
+derfor en forudsætning, at disse dumps stadig er til rådighed.
+For at synkronisere en enkelt medarbejder anvedes disse kommandolinjeparametre:
+
+* ``--update-single-user``: Ansættelsesnummer på den relevante medarbejder
+* ``days``: Antal dage bagud integrationen skal søge.
+
+
 Opsætning af agenten til re-import
 ----------------------------------
 

--- a/integrations/opus/opus_diff_import.py
+++ b/integrations/opus/opus_diff_import.py
@@ -806,6 +806,34 @@ class OpusDiffImport(object):
         logger.debug('Terminate response: {}'.format(response.text))
         self._assert(response)
 
+    def import_single_employment(self, employee):
+        # logger.info('Update  employment {} from {}'.format(employment, xml_file))
+        last_changed_str = employee.get('@lastChanged')
+        if last_changed_str is not None:  # This is a true employee-object.
+            self.update_employee(employee)
+
+            if 'function' in employee:
+                self.update_roller(employee)
+            else:
+                # TODO:  Terminate existing roles
+                pass
+        else:  # This is an implicit termination.
+
+            # This is a terminated employee, check if engagement is active
+            # terminate if it is.
+            if not employee['@action'] == 'leave':
+                msg = 'Missing date on a non-leave object!'
+                logger.error(msg)
+                raise Exception(msg)
+
+            org_funk_info = self._find_engagement(employee['@id'], present=True)
+            if org_funk_info:
+                logger.info('Terminating: {}'.format(org_funk_info))
+                self.terminate_detail(org_funk_info['engagement'])
+                if 'manager' in org_funk_info:
+                    self.terminate_detail(org_funk_info['manager'],
+                                          detail_type='manager')
+
     def start_re_import(self, xml_file, include_terminations=False):
         """
         Start an opus import, run the oldest available dump that

--- a/integrations/opus/opus_diff_import.py
+++ b/integrations/opus/opus_diff_import.py
@@ -815,10 +815,13 @@ class OpusDiffImport(object):
             if 'function' in employee:
                 self.update_roller(employee)
             else:
-                # TODO:  Terminate existing roles
-                pass
+                # Terminate existing roles
+                mo_user = self.helper.read_user(user_cpr=employee['cpr']['#text'])
+                for role in self.role_cache:
+                    if role['person'] == mo_user['uuid']:
+                        logger.info('Terminating role: {}'.format(role))
+                        self.terminate_detail(role['uuid'], detail_type='role')
         else:  # This is an implicit termination.
-
             # This is a terminated employee, check if engagement is active
             # terminate if it is.
             if not employee['@action'] == 'leave':

--- a/integrations/opus/opus_helpers.py
+++ b/integrations/opus/opus_helpers.py
@@ -42,7 +42,7 @@ def _read_cpr_mapping():
     return employee_forced_uuids
 
 
-def _read_available_dumps():
+def read_available_dumps():
     dumps = {}
 
     for opus_dump in DUMP_PATH.glob('*.xml'):
@@ -137,7 +137,7 @@ def start_opus_import(importer, ad_reader=None, force=False):
     Start an opus import, run the oldest available dump that
     has not already been imported.
     """
-    dumps = _read_available_dumps()
+    dumps = read_available_dumps()
 
     run_db = Path(SETTINGS['integrations.opus.import.run_db'])
     if not run_db.is_file():
@@ -180,7 +180,7 @@ def start_opus_diff(ad_reader=None):
     Start an opus update, use the oldest available dump that has not
     already been imported.
     """
-    dumps = _read_available_dumps()
+    dumps = read_available_dumps()
     run_db = Path(SETTINGS['integrations.opus.import.run_db'])
 
     employee_mapping = _read_cpr_mapping()
@@ -205,7 +205,6 @@ def start_opus_diff(ad_reader=None):
         _local_db_insert((xml_date, 'Diff update ended: {}'))
 
 
-# Denne bør nok også bruges af import og diff_import
 def read_dump_data(dump_file):
     cache_file = pathlib.Path.cwd() / 'tmp' / (dump_file.stem + '.p')
     if not cache_file.is_file():
@@ -244,7 +243,7 @@ def update_employee(employee_number, days):
 
     current_object = {}
     cut_date = datetime.datetime.now() - datetime.timedelta(days=days)
-    dumps = _read_available_dumps()
+    dumps = read_available_dumps()
 
     for date in sorted(dumps.keys()):
         print(date)

--- a/integrations/opus/test_opus_connectivity.py
+++ b/integrations/opus/test_opus_connectivity.py
@@ -1,0 +1,266 @@
+import json
+import requests
+import argparse
+
+from pathlib import Path
+from os2mo_helpers.mora_helpers import MoraHelper
+
+
+# Todo: Add logger
+
+class TestOpusConnectivity(object):
+    def __init__(self):
+        cfg_file = Path.cwd() / 'settings' / 'settings.json'
+        if not cfg_file.is_file():
+            raise Exception('No setting file')
+        try:
+            self.settings = json.loads(cfg_file.read_text())
+        except json.decoder.JSONDecodeError as e:
+            print('Syntax error in settings file: {}'.format(e))
+            exit(1)
+
+        self.helper = MoraHelper(hostname=self.settings['mora.base'],
+                                 use_cache=False)
+
+    def _test_saml(self):
+        print('Tester adgang til MO (især SAML)')
+        try:
+            self.helper.read_organisation()
+            print(' * Kan tilgå MO uden problemer')
+            print()
+        except requests.exceptions.RequestException:
+            print(' * Har ikke adgang til MO, check SAML eller hostnavn')
+            exit(1)
+
+    def _check_bare_minimum_keys(self):
+        print('Tjeck for tilstedeværelse af konfigurationsnøgler')
+        needed_keys = [
+            'mora.base',
+            'municipality.name',
+            'integrations.opus.import.run_db',
+            'integrations.opus.import.xml_path',
+            'integrations.opus.eng_types_primary_order'
+        ]
+
+        missing_keys = []
+        for key in needed_keys:
+            if self.settings.get(key) is None:
+                missing_keys.append(key)
+        if missing_keys:
+            print(' * Manglende nøgler: {}'.format(missing_keys))
+            exit(1)
+        else:
+            print(' * Alle nødvendige nøgler fundet')
+            print()
+
+    def _check_xml_files_availability(self):
+        print('Tjeck der findes xml-filer at importere')
+        # Import will fail non-gracefully if keys are missing, hold import
+        # until bare_minimum_check is performed
+        from integrations.opus import opus_helpers
+        dumps = opus_helpers.read_available_dumps()
+        if len(dumps) == 0:
+            msg = ' * Fandt ingen xml-filer i {}'
+            print(msg.format(self.settings['integrations.opus.import.xml_path']))
+            exit(1)
+        else:
+            newest_dump = sorted(dumps)[-1]
+            msg = ' * Fandt {}-xml filer. Nyeste fil fra {}'
+            print(msg.format(len(dumps), newest_dump))
+            print()
+
+    def _check_keys_for_diff_import(self):
+        print('Tjeck for tilstedeværelse af nøgler for diff-import')
+        print('Disse klasser oprettes af initial-import')
+        diff_keys = [
+            'mox.base',
+            'opus.addresses.employee.dar',
+            'opus.addresses.employee.phone',
+            'opus.addresses.employee.email',
+            'opus.addresses.unit.se',
+            'opus.addresses.unit.cvr',
+            'opus.addresses.unit.ean',
+            'opus.addresses.unit.pnr',
+            'opus.addresses.unit.phoneNumber',
+            'opus.addresses.unit.dar',
+            'integrations.opus.it_systems.ad',
+            'integrations.opus.it_systems.opus'
+        ]
+
+        missing_keys = []
+        for key in diff_keys:
+            if self.settings.get(key) is None:
+                missing_keys.append(key)
+        if missing_keys:
+            print(' * Manglende nøgler: {}'.format(missing_keys))
+            exit(1)
+        else:
+            print(' * Alle nøgler for diff-import er fundet')
+            print()
+
+    def _check_lora_klasse(self, uuid, facet=None):
+        url = '/klassifikation/klasse/'
+        mox = self.settings['mox.base']
+        response = requests.get(mox + url + uuid)
+        if not response.status_code == 200:
+            return False
+
+        if facet:
+            klasse = response.json()
+            facet_uuid = (klasse[uuid][0]['registreringer'][0]['relationer']
+                          ['facet'][0]['uuid'])
+            url = '/klassifikation/facet/'
+            facet_response = requests.get(mox + url + facet_uuid)
+            raw_facet = facet_response.json()
+            facet_titel = (
+                raw_facet[facet_uuid][0]['registreringer'][0]['attributter']
+                ['facetegenskaber'][0]['brugervendtnoegle']
+            )
+            if not facet_titel == facet:
+                return False
+        return True
+
+    def _check_existense_of_base_klasser(self):
+        print('Tjekker at engagements-typer for primærberegning eksisterer')
+        bad_classes = []
+        if not self.settings['integrations.opus.eng_types_primary_order']:
+            print(' * Listen over primær-klasser er tom')
+            exit(1)
+
+        for uuid in self.settings['integrations.opus.eng_types_primary_order']:
+            if not self._check_lora_klasse(uuid, facet='engagement_type'):
+                bad_classes.append(uuid)
+
+        if bad_classes:
+            msg = ' * Klasse eksisterer ikke, eller ikke facet engagement_type: {}'
+            print(msg.format(bad_classes))
+            exit(1)
+        else:
+            print('* De angivne klasser til primærberegning er gyldige')
+            print()
+
+    def _check_legal_diff_klasser(self):
+        print('Tjekker at de angivne adresseklasser eksisterer')
+        bad_classes = []
+        for uuid in [
+                self.settings['opus.addresses.employee.dar'],
+                self.settings['opus.addresses.employee.phone'],
+                self.settings['opus.addresses.employee.email']
+        ]:
+            if not self._check_lora_klasse(uuid, facet='employee_address_type'):
+                bad_classes.append(uuid)
+
+        for uuid in [
+                self.settings['opus.addresses.unit.se'],
+                self.settings['opus.addresses.unit.cvr'],
+                self.settings['opus.addresses.unit.ean'],
+                self.settings['opus.addresses.unit.pnr'],
+                self.settings['opus.addresses.unit.phoneNumber'],
+                self.settings['opus.addresses.unit.dar']
+        ]:
+            if not self._check_lora_klasse(uuid, facet='org_unit_address_type'):
+                bad_classes.append(uuid)
+
+        if bad_classes:
+            msg = ' * Klasse eksisterer ikke, eller har forkert facet: {}'
+            print(msg.format(bad_classes))
+            exit(1)
+        else:
+            print('* De angivne adresseklasser er gyldige')
+            print()
+
+    def _check_run_db(self, should_be_empty: bool):
+        run_db = Path(self.settings['integrations.opus.import.run_db'])
+        existing_run_db = run_db.is_file()
+
+        if should_be_empty:
+            print('Dette er førstegangsimport, tjek at run-db ikke findes:')
+            if existing_run_db:
+                print('run-db eksisterer! Skal fjernes før førstegangsimport')
+                exit(1)
+            else:
+                print('Der findes (korrekt) ikke nogen run-db')
+
+        else:
+            print('Dette er diff-import, tjek at run-db findes:')
+            if not existing_run_db:
+                print('run-db eksisterer ikke! Udfør førstegangsimport!')
+                exit(1)
+            else:
+                print(' * run-db findes som den skal')
+                print()
+
+    def _check_is_systems(self):
+        print('Tjekker at opsætning af IT-systemer er korrekt')
+        mo_it_systems = self.helper.read_it_systems()
+
+        # Check opus
+        found_opus = None
+        opus = self.settings['integrations.opus.it_systems.opus']
+        for it_system in mo_it_systems:
+            if it_system['uuid'] == opus:
+                found_opus = it_system['name']
+
+        if not found_opus:
+            msg = ' * Fandt ikke IT-system Opus med uuid: {}'
+            print(msg.format(opus))
+            exit(1)
+        else:
+            if found_opus.lower().find('opus') > -1:
+                msg = ' * Fandt korrekt IT system til Opus: {}'
+            else:
+                msg = ' * Fandt IT system til Opus, men med navnet {}????'
+            print(msg.format(found_opus))
+
+        # Check ad
+        found_ad = None
+        ad = self.settings['integrations.opus.it_systems.ad']
+        for it_system in mo_it_systems:
+            if it_system['uuid'] == ad:
+                found_ad = it_system['name']
+
+        if not found_ad:
+            msg = ' * Fandt ikke IT-system AD med uuid: {}'
+            print(msg.format(ad))
+            exit(1)
+        else:
+            ad_names = ['ad', 'active directory']
+            name_matched = False
+            for name in ad_names:
+                if found_ad.lower().find(name) > -1:
+                    name_matched = True
+            if name_matched:
+                msg = ' * Fandt korrekt IT system til AD: {}'
+            else:
+                msg = ' * Fandt IT system til AD, men med navnet {}????'
+            print(msg.format(found_ad))
+            print()
+
+    def base_opus_check(self):
+        self._test_saml()
+        self._check_bare_minimum_keys()
+        self._check_xml_files_availability()
+        self._check_existense_of_base_klasser()
+
+    def diff_opus_check(self):
+        self._check_keys_for_diff_import()
+        self._check_legal_diff_klasser()
+        self._check_is_systems()
+        self._check_run_db(should_be_empty=False)
+
+    def cli(self):
+        parser = argparse.ArgumentParser(description='Test opus configuration')
+        parser.add_argument('--test-diff-import', action='store_true')
+        args = vars(parser.parse_args())
+
+        self.base_opus_check()
+
+        if args['test_diff_import']:
+            self.diff_opus_check()
+        else:
+            self._check_run_db(should_be_empty=True)
+
+
+if __name__ == '__main__':
+    toc = TestOpusConnectivity()
+    toc.cli()

--- a/integrations/rebild/rebild.py
+++ b/integrations/rebild/rebild.py
@@ -29,7 +29,6 @@ SETTINGS = json.loads(cfg_file.read_text())
 
 ad_reader = ad_reader.ADParameterReader()
 
-
 if args['update']:
     try:
         start_opus_diff(ad_reader=ad_reader)
@@ -37,7 +36,6 @@ if args['update']:
         print('RunDB not initialized')
 
 if args['import']:
-
     importer = ImportHelper(
         create_defaults=True,
         mox_base=SETTINGS['mox.base'],

--- a/integrations/rebild/rebild.py
+++ b/integrations/rebild/rebild.py
@@ -5,6 +5,7 @@ import argparse
 from os2mo_data_import import ImportHelper
 
 from integrations.ad_integration import ad_reader
+from integrations.opus.opus_helpers import update_employee
 from integrations.opus.opus_helpers import start_opus_diff
 from integrations.opus.opus_helpers import start_opus_import
 from integrations.opus.opus_exceptions import RunDBInitException
@@ -13,10 +14,14 @@ parser = argparse.ArgumentParser(description='Rebild import')
 group = parser.add_mutually_exclusive_group()
 group.add_argument('--import', action='store_true', help='New import into empty MO')
 group.add_argument('--update', action='store_true', help='Update with next xml file')
+group.add_argument('--update-single-user', nargs=1, metavar='Emmploymentnumber',
+                   help='Update a single user')
+parser.add_argument('--days', nargs=1, type=int, metavar='Days to go back',
+                    help='Number of days in the past to sync single user',
+                    default=[1000])
+
 args = vars(parser.parse_args())
 
-# TODO: Soon we have done this 4 times. Should we make a small settings
-# importer, that will also handle datatype for specicic keys?
 cfg_file = pathlib.Path.cwd() / 'settings' / 'settings.json'
 if not cfg_file.is_file():
     raise Exception('No setting file')
@@ -46,3 +51,8 @@ if args['import']:
         start_opus_import(importer, ad_reader=ad_reader, force=True)
     except RunDBInitException:
         print('RunDB not initialized')
+
+if args.get('update_single_user'):
+    employment_number = args.get('update_single_user')[0]
+    days = args['days'][0]
+    update_employee(employment_number, days)

--- a/integrations/sorø/sorø.py
+++ b/integrations/sorø/sorø.py
@@ -5,6 +5,7 @@ import argparse
 from os2mo_data_import import ImportHelper
 
 from integrations.ad_integration import ad_reader
+from integrations.opus.opus_helpers import update_employee
 from integrations.opus.opus_helpers import start_opus_diff
 from integrations.opus.opus_helpers import start_opus_import
 from integrations.opus.opus_exceptions import RunDBInitException
@@ -13,10 +14,14 @@ parser = argparse.ArgumentParser(description='Sorø import')
 group = parser.add_mutually_exclusive_group()
 group.add_argument('--import', action='store_true', help='New import into empty MO')
 group.add_argument('--update', action='store_true', help='Update with next xml file')
+group.add_argument('--update-single-user', nargs=1, metavar='Emmploymentnumber',
+                   help='Update a single user')
+parser.add_argument('--days', nargs=1, type=int, metavar='Days to go back',
+                    help='Number of days in the past to sync single user',
+                    default=[1000])
+
 args = vars(parser.parse_args())
 
-# TODO: Soon we have done this 4 times. Should we make a small settings
-# importer, that will also handle datatype for specicic keys?
 cfg_file = pathlib.Path.cwd() / 'settings' / 'settings.json'
 if not cfg_file.is_file():
     raise Exception('No setting file')
@@ -24,16 +29,13 @@ SETTINGS = json.loads(cfg_file.read_text())
 
 ad_reader = ad_reader.ADParameterReader()
 
-
 if args['update']:
     try:
         start_opus_diff(ad_reader=ad_reader)
     except RunDBInitException:
         print('RunDB not initialized')
     
-
 if args['import']:
-
     importer = ImportHelper(
         create_defaults=True,
         mox_base=SETTINGS['mox.base'],
@@ -67,3 +69,8 @@ if args['import']:
         start_opus_import(importer, ad_reader=ad_reader, force=True)
     except RunDBInitException:
         print('RunDB not initialized')
+
+if args.get('update_single_user'):
+    employment_number = args.get('update_single_user')[0]
+    days = args['days'][0]
+    update_employee(employment_number, days)

--- a/tools/job-runner.sh
+++ b/tools/job-runner.sh
@@ -89,6 +89,12 @@ imports_test_sd_connectivity(){
     ${VENV}/bin/python3 integrations/SD_Lon/test_sd_connectivity.py
 }
 
+imports_test_opus_connectivity(){
+    set -e
+    echo running imports_test_ops_connectivity
+    ${VENV}/bin/python3 integrations/opus/test_opus_connectivity.py --test-diff-import
+}
+
 imports_sd_fix_departments(){
     set -e
     BACK_UP_AND_TRUNCATE+=(
@@ -380,7 +386,11 @@ imports(){
     if [ "${RUN_CHECK_SD_CONNECTIVITY}" == "true" ]; then
         run-job imports_test_sd_connectivity || return 2
     fi
-    
+
+    if [ "${RUN_CHECK_OPUS_CONNECTIVITY}" == "true" ]; then
+        run-job imports_test_opus_connectivity || return 2
+    fi
+
     if [ "${RUN_SD_FIX_DEPARTMENTS}" == "true" ]; then
         run-job imports_sd_fix_departments || return 2
     fi


### PR DESCRIPTION
Har udarbejdet en funktion som tillader eftersynkronisering af enkelte medarbejdere hvis det skulle blive nødvendigt. Koden vil desuden kunne danne udgangspunk hvis det på et tidspunkt bliver nødvendigt at lave imports hvor lastChanged ignoreres.

Første udgave af test_opus_connectivity, som analogt til test_sd_connectivity, tester om der findes den nødvendige konfiguration til at kunne foretage et opus-import. Funktionen tager en enkelt parameter som angiver om der testes for førstegangsimport eller diff-import.