### PR TITLE
Fixed typos in calculate_primary.py

### DIFF
--- a/integrations/SD_Lon/calculate_primary.py
+++ b/integrations/SD_Lon/calculate_primary.py
@@ -182,7 +182,7 @@ class MOPrimaryEngagementUpdater(object):
 
     def recalculate_primary(self, no_past=False):
         """
-        Re-calculate primary engagement for the enire history of the current user.
+        Re-calculate primary engagement for the entire history of the current user.
         """
         logger.info('Calculate primary engagement: {}'.format(self.mo_person))
         date_list = self._find_cut_dates(no_past=no_past)

--- a/integrations/opus/calculate_primary.py
+++ b/integrations/opus/calculate_primary.py
@@ -157,7 +157,7 @@ class MOPrimaryEngagementUpdater(object):
 
     def recalculate_primary(self, no_past=True):
         """
-        Re-calculate primary engagement for the enire history of the current user.
+        Re-calculate primary engagement for the entire history of the current user.
         """
         logger.info('Calculate primary engagement: {}'.format(self.mo_person))
         date_list = self.helper.find_cut_dates(self.mo_person['uuid'],


### PR DESCRIPTION
This PR fixes two tiny typos in comments.